### PR TITLE
Add Postscript blue zones for letters and numbers

### DIFF
--- a/sources/CascadiaCode-Regular.ufo/fontinfo.plist
+++ b/sources/CascadiaCode-Regular.ufo/fontinfo.plist
@@ -205,7 +205,16 @@ THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
     <key>openTypeOS2VendorID</key>
     <string>SAJA</string>
     <key>postscriptBlueValues</key>
-    <array/>
+    <array>
+      <integer>-20</integer>
+      <integer>0</integer>
+      <integer>1060</integer>
+      <integer>1080</integer>
+      <integer>1420</integer>
+      <integer>1440</integer>
+      <integer>1500</integer>
+      <integer>1520</integer>
+    </array>
     <key>postscriptFamilyBlues</key>
     <array/>
     <key>postscriptFamilyOtherBlues</key>
@@ -213,11 +222,22 @@ THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
     <key>postscriptIsFixedPitch</key>
     <true/>
     <key>postscriptOtherBlues</key>
-    <array/>
+    <array>
+      <integer>-480</integer>
+      <integer>-460</integer>
+    </array>
     <key>postscriptStemSnapH</key>
-    <array/>
+    <array>
+      <integer>200</integer>
+      <integer>210</integer>
+      <integer>212</integer>
+      <integer>220</integer>
+    </array>
     <key>postscriptStemSnapV</key>
-    <array/>
+    <array>
+      <integer>180</integer>
+      <integer>190</integer>
+    </array>
     <key>postscriptUnderlinePosition</key>
     <integer>-100</integer>
     <key>postscriptUnderlineThickness</key>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What character(s) are you changing/creating and how was it tested (even manually, if necessary)? Did you hint the entire font or only the modified character(s)? -->
## Summary of the Pull Request

Add Postscript blue zones that enclose letters and common numbers and define vertical and horizontal stem widths. This helps with autohinting OTFs.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] ~~Closes #xxx~~
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Requires FONTLOG.txt to be updated
* [ ] Requires [/images/cascadia-code.png](/microsoft/cascadia-code/blob/master/images/cascadia-code.png) and/or [/images/cascadia-code-characters.png](/microsoft/cascadia-code/blob/master/images/cascadia-code-characters.png) to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. ~~Issue number where discussion took place: #xxx~~

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

When not producing TTFs but OTFs, hinting is a matter of running https://github.com/adobe-type-tools/psautohint/ on the resulting binary. For the autohinter to do its job, it needs to know the standard widths of a font plus so-called blue zones, which tell the tool which heights points of a glyph should be snapped to. They also help with consistency in the design phase, because e.g. Glyphs will indicate when a point is within or outside a blue zone.

TTFs are unaffected by this change since the format does not use them.

<!-- Provide images of the character(s) that are being modified/created at different screen sizes. Clearly identifying specific code points is heavily recommended. -->
## ~~Before (if applicable) and~~ After Images of the Character(s)

![Bildschirmfoto von 2019-11-20 20-49-41](https://user-images.githubusercontent.com/380829/69277007-63e44580-0bd7-11ea-8c71-025f4df63e1c.png)
![Bildschirmfoto von 2019-11-20 20-49-45](https://user-images.githubusercontent.com/380829/69277113-95f5a780-0bd7-11ea-9684-75144dad35e1.png)
![Bildschirmfoto von 2019-11-20 20-49-50](https://user-images.githubusercontent.com/380829/69277115-968e3e00-0bd7-11ea-97bd-d38cd518e4d6.png)
![Bildschirmfoto von 2019-11-20 20-54-16](https://user-images.githubusercontent.com/380829/69277287-eff66d00-0bd7-11ea-9c81-f9c78b4096de.png)

<!-- Describe how you validated the behavior. List steps that were taken. -->
## Validation Steps Performed

Manually looking at the resulting font in a terminal and in VSCode.