### PR TITLE
Adding GASP table data & removing from VTT ttx

### DIFF
--- a/build.py
+++ b/build.py
@@ -51,7 +51,7 @@ def build_font_instance(generator, instance_descriptor, *steps):
 
     setattr(instance.info, "openTypeOS2Panose", [2, 11, 6, 9, 2, 0, 0, 2, 0, 4])
 
-    instance.info._openTypeGaspRangeRecords =[
+    instance.info.openTypeGaspRangeRecords =[
         {
             "rangeMaxPPEM" : 9, 
             "rangeGaspBehavior" : [1,3]

--- a/build.py
+++ b/build.py
@@ -51,6 +51,21 @@ def build_font_instance(generator, instance_descriptor, *steps):
 
     setattr(instance.info, "openTypeOS2Panose", [2, 11, 6, 9, 2, 0, 0, 2, 0, 4])
 
+    instance.info._openTypeGaspRangeRecords =[
+        {
+            "rangeMaxPPEM" : 9, 
+            "rangeGaspBehavior" : [1,3]
+        },
+        {
+            "rangeMaxPPEM" : 50, 
+            "rangeGaspBehavior" : [0,1,2,3]
+        },
+        {
+            "rangeMaxPPEM" : 65535, 
+            "rangeGaspBehavior" : [1,3]
+        },
+    ]      
+
     familyName = instance.info.familyName
     file_name = f"{familyName}.ttf".replace(" ", "")
     file_path = OUTPUT_DIR / file_name

--- a/sources/vtt_data/CascadiaCode.ttx
+++ b/sources/vtt_data/CascadiaCode.ttx
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.0">
 
-<gasp>
-    <gaspRange rangeMaxPPEM="9" rangeGaspBehavior="10"/>
-    <gaspRange rangeMaxPPEM="65535" rangeGaspBehavior="15"/>
-</gasp>
-
 <TSI0>
     <!-- This table will be calculated by the compiler -->
 </TSI0>


### PR DESCRIPTION
## Summary of the Pull Request

This PR adds the GASP table to the build.py script to enable consistent rendering across the different iterations of the font. 

## PR Checklist
* [x] Closes #193 
* [x] CLA signed.
* [x] I've discussed this with core contributors already.

## Detailed Description of the Pull Request / Additional comments

Code adds a gasp table that turns on smoothing, and enables hinting between 9ppem and 50ppem. 

## Validation Steps Performed

Built font with script and verified the correct GASP setting have been set. 