### PR TITLE
Add U+2011 NON-BREAKING HYPHEN

### DIFF
--- a/FONTLOG.txt
+++ b/FONTLOG.txt
@@ -29,6 +29,12 @@ ChangeLog
 - Font converted to UFO with a build workflow
 - font rehinted
 - many other fixes!
+12-20-2019 (Aaron Bell) Cascadia Code (Minor Updates)
+- Fix issues with ATSUI (an older Apple layout engine)
+- Add remaining Codepage 437 glyphs
+- Add the unicode hyphen U+2010
+12-30-2019 (Dustin Howett) Cascadia Code (Minor Updates)
+- Add U+2011 NON-BREAKING HYPHEN
 
 Acknowledgements
 -----------------------------------

--- a/sources/CascadiaCode-Regular.ufo/glyphs/contents.plist
+++ b/sources/CascadiaCode-Regular.ufo/glyphs/contents.plist
@@ -2372,6 +2372,8 @@
     <string>nje-cy.glif</string>
     <key>nmod</key>
     <string>nmod.glif</string>
+    <key>nonbreakinghyphen</key>
+    <string>nonbreakinghyphen.glif</string>
     <key>note-musical</key>
     <string>note-musical.glif</string>
     <key>notedbl-musical</key>

--- a/sources/CascadiaCode-Regular.ufo/glyphs/nonbreakinghyphen.glif
+++ b/sources/CascadiaCode-Regular.ufo/glyphs/nonbreakinghyphen.glif
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="nonbreakinghyphen" format="2">
+  <advance width="1200"/>
+  <unicode hex="2011"/>
+  <outline>
+    <component base="hyphentwo"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2019/12/30 05:27:01</string>
+    </dict>
+  </lib>
+</glyph>


### PR DESCRIPTION
## PR Checklist
* [x] Closes #222
* [x] CLA
* [x] FONTLOG updated
* [ ] Requires [/images/cascadia-code.png](/microsoft/cascadia-code/blob/master/images/cascadia-code.png) and/or [/images/cascadia-code-characters.png](/microsoft/cascadia-code/blob/master/images/cascadia-code-characters.png) to be updated
* [x] I'm a core contributor

## Detailed Description of the Pull Request / Additional comments

This is an easy one: other fonts also base this glyph on the hyphen.

## Before (if applicable) and After Images of the Character

Before: it doesn't exist
After: it is a hyphen

## Validation Steps Performed

Popped the font open in a font viewer.