### PR TITLE
Fix casing in build paths for feature files

### DIFF
--- a/build.py
+++ b/build.py
@@ -204,7 +204,7 @@ if __name__ == "__main__":
                     generator,
                     instance_descriptor,
                     step_set_font_name("Cascadia Code PL"),
-                    step_set_feature_file(INPUT_DIR / "features" / "features_code_pl.fea"),
+                    step_set_feature_file(INPUT_DIR / "features" / "features_code_PL.fea"),
                     step_merge_pl,
                 )
 
@@ -252,7 +252,7 @@ if __name__ == "__main__":
         build_variable_fonts(
             designspace,
             step_set_font_name("Cascadia Code PL"),
-            step_set_feature_file(INPUT_DIR / "features" / "features_code_pl.fea"),
+            step_set_feature_file(INPUT_DIR / "features" / "features_code_PL.fea"),
             step_merge_pl,
         )
 
@@ -260,7 +260,7 @@ if __name__ == "__main__":
             build_variable_fonts(
                 designspace,
                 step_set_font_name("Cascadia Mono PL"),
-                step_set_feature_file(INPUT_DIR / "features" / "features_mono_pl.fea"),
+                step_set_feature_file(INPUT_DIR / "features" / "features_mono_PL.fea"),
                 step_merge_pl,
             )
 


### PR DESCRIPTION

<!-- Enter a brief description/summary of your PR here. What character(s) are you changing/creating and how was it tested (even manually, if necessary)? Did you hint the entire font or only the modified character(s)? -->
## Summary of the Pull Request

Make some paths in build.py case-exact because Linux filesystems tend to be case-sensitive.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Requires FONTLOG.txt to be updated
* [ ] Requires [/images/cascadia-code.png](/microsoft/cascadia-code/blob/master/images/cascadia-code.png) and/or [/images/cascadia-code-characters.png](/microsoft/cascadia-code/blob/master/images/cascadia-code-characters.png) to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.

<!-- Describe how you validated the behavior. List steps that were taken. -->
## Validation Steps Performed

Local build.