### PR TITLE
build.py: Check subprocess calls, add psautohint dependency

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import argparse
+import os
 
 import fontmake.instantiator
 import fontTools.designspaceLib
@@ -302,10 +303,12 @@ if __name__ == "__main__":
 
     otfs = list(Path("build").glob("*.otf"))
     if otfs:
-        print("Autohinting and compressing OTFs")
-        for file in otfs:
-            subprocess.run([f'psautohint --log "build/log.txt" {str(file)}'], shell=True)
-            subprocess.run([f'python -m cffsubr -i {str(file)}'], shell=True)
+        for otf in otfs:
+            path = os.fspath(otf)
+            print(f"Autohinting {path}")
+            subprocess.check_call(["psautohint", "--log", "build/log.txt", path])
+            print(f"Compressing {path}")
+            subprocess.check_call(["python", "-m", "cffsubr", "-i", path])
 
     print("All done")
     print("*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***")

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,8 @@
+# Add or remove dependencies here and then use pip-tool's 
+#   pip-compile -U requirements.in
+# to update requirements.txt (the lock file, so to speak).
+
 fontmake
+psautohint
 statmake
 vttLib

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,10 +13,11 @@ compreffor==0.5.0         # via ufo2ft
 cu2qu==1.6.7              # via fontmake, ufo2ft
 fontmake==2.2.0           # via -r requirements.in
 fontmath==0.6.0           # via fontmake
-fonttools[lxml,ufo,unicode]==4.12.1  # via booleanoperations, cffsubr, compreffor, cu2qu, fontmake, fontmath, glyphslib, statmake, ufo2ft, ufolib2, vttlib
+fonttools[lxml,ufo,unicode]==4.12.1  # via booleanoperations, cffsubr, compreffor, cu2qu, fontmake, fontmath, glyphslib, psautohint, statmake, ufo2ft, ufolib2, vttlib
 fs==2.4.11                # via fonttools
 glyphslib==5.1.10         # via fontmake
 lxml==4.5.1               # via fonttools
+psautohint==2.1.0         # via -r requirements.in
 pyclipper==1.1.0.post3    # via booleanoperations
 pyparsing==2.4.7          # via vttlib
 pytz==2020.1              # via fs


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What character(s) are you changing/creating and how was it tested (even manually, if necessary)? Did you hint the entire font or only the modified character(s)? -->
## Summary of the Pull Request

1. Add psautohint dependency, which I previously accidentally booted out.
2. Make the build script check the calls to other programs and have it error out on errors.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Requires FONTLOG.txt to be updated
* [ ] Requires [/images/cascadia-code.png](/microsoft/cascadia-code/blob/master/images/cascadia-code.png) and/or [/images/cascadia-code-characters.png](/microsoft/cascadia-code/blob/master/images/cascadia-code-characters.png) to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

1. We need psautohint in requirements.in and regenerate a fresh requirements.txt from that, to be used on the CI, etc.
2. `subprocess.run` fires and forgets a command. `subprocess.check_call` will raise an error on a non-zero exit status of the command.

<!-- Describe how you validated the behavior. List steps that were taken. -->
## Validation Steps Performed

CI build hopefully?