### PR TITLE
Some build.py cleanup

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,4 +31,4 @@ jobs:
     - name: Lint sources
       run: ufolint sources/*.ufo
     - name: Build font(s)
-      run: python build.py
+      run: python build.py -S

--- a/build.py
+++ b/build.py
@@ -114,23 +114,26 @@ def build_variable_fonts(designspace, *steps):
 
     print(f"[{familyName}] Done: {file_path}")
 
-    print(f"[{familyName}] Compiling CFF2")
-    file_path_cff2 = (OUTPUT_DIR / file_stem).with_suffix(f".otf")
-    #Do not optimize, because we have to do it again after autohinting.
-    varFontCFF2 = ufo2ft.compileVariableCFF2(designspace,
-       inplace=True,
-       useProductionNames=True,
-       optimizeCFF=ufo2ft.CFFOptimization.NONE,
-    )
+    # XXX: Disable variable OTF (CFF2) compilation until psautohint can better
+    #      deal with overlaps: https://github.com/adobe-type-tools/psautohint/issues/40
+    
+    # print(f"[{familyName}] Compiling CFF2")
+    # file_path_cff2 = (OUTPUT_DIR / file_stem).with_suffix(f".otf")
+    # # Do not optimize, because we have to do it again after autohinting.
+    # varFontCFF2 = ufo2ft.compileVariableCFF2(
+    #    designspace,
+    #    inplace=True,  # Can compile in-place because `designspace` won't be reused here.
+    #    useProductionNames=True,
+    #    optimizeCFF=ufo2ft.CFFOptimization.NONE,
+    # )
 
-    print(f"[{familyName}] Adding STAT table")
-    styleSpace = classes.Stylespace.from_file(INPUT_DIR / "STAT.plist")
-    lib.apply_stylespace_to_variable_font(styleSpace,varFontCFF2,{})
+    # print(f"[{familyName}] Adding STAT table")
+    # lib.apply_stylespace_to_variable_font(styleSpace,varFontCFF2,{})
 
-    print(f"[{familyName}] Saving")
-    varFontCFF2.save(file_path_cff2)
+    # print(f"[{familyName}] Saving")
+    # varFontCFF2.save(file_path_cff2)
 
-    print(f"[{familyName}] Done: {file_path_cff2}")
+    # print(f"[{familyName}] Done: {file_path_cff2}")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="build some fonts")

--- a/build.py
+++ b/build.py
@@ -220,7 +220,6 @@ if __name__ == "__main__":
                         generator,
                         instance_descriptor,
                         step_set_font_name("Cascadia Mono NF"),
-                        step_remove_ligatures,
                         step_merge_nf,
                     )
 
@@ -265,7 +264,6 @@ if __name__ == "__main__":
             build_variable_fonts(
                 designspace,
                 step_set_font_name("Cascadia Mono NF"),
-                step_remove_ligatures,
                 step_merge_nf,
             )
 

--- a/build.py
+++ b/build.py
@@ -46,38 +46,6 @@ def step_set_feature_file(n):
 
     return _set
 
-def set_font_metaData(font, sort):
-    font.info.versionMajor = 2007
-    font.info.versionMinor = 1
-
-    font.info.openTypeOS2Panose = [2, 11, 6, 9, 2, 0, 0, 2, 0, 4]
-
-    font.info.openTypeOS2TypoAscender = 1900
-    font.info.openTypeOS2TypoDescender = -480
-    font.info.openTypeOS2TypoLineGap = 0
-
-    font.info.openTypeHheaAscender = font.info.openTypeOS2TypoAscender
-    font.info.openTypeHheaDescender = font.info.openTypeOS2TypoDescender
-    font.info.openTypeHheaLineGap = font.info.openTypeOS2TypoLineGap
-
-    font.info.openTypeOS2WinAscent = 2226
-    font.info.openTypeOS2WinDescent = abs(font.info.openTypeOS2TypoDescender)
-
-    if sort != "otf":
-        font.info.openTypeGaspRangeRecords =[
-            {
-                "rangeMaxPPEM" : 9,
-                "rangeGaspBehavior" : [1,3]
-            },
-            {
-                "rangeMaxPPEM" : 50,
-                "rangeGaspBehavior" : [0,1,2,3]
-            },
-            {
-                "rangeMaxPPEM" : 65535,
-                "rangeGaspBehavior" : [1,3]
-            },
-        ]
 
 def build_font_instance(generator, instance_descriptor, *steps):
     for format in ["otf"]: # removed TTF from here
@@ -85,9 +53,6 @@ def build_font_instance(generator, instance_descriptor, *steps):
 
         for step in steps:
             step(instance)
-
-
-        set_font_metaData(instance, format)
 
         familyName = instance.info.familyName
         fontName = familyName +" "+instance.info.styleName
@@ -119,9 +84,6 @@ def build_font_instance(generator, instance_descriptor, *steps):
 def build_variable_fonts(designspace, *steps):
 
     sourceFonts = [ufoLib2.Font.open(INPUT_DIR / designspace.sources[0].filename), ufoLib2.Font.open(INPUT_DIR / designspace.sources[1].filename), ufoLib2.Font.open(INPUT_DIR / designspace.sources[2].filename)]
-
-    for source in sourceFonts:
-        set_font_metaData(source, "var")
 
     designspace.sources[0].font = sourceFonts[0] #ExtraLight
     designspace.sources[1].font = sourceFonts[1] #Regular

--- a/sources/CascadiaCode-Bold.ufo/fontinfo.plist
+++ b/sources/CascadiaCode-Bold.ufo/fontinfo.plist
@@ -165,8 +165,46 @@
     </array>
     <key>italicAngle</key>
     <integer>0</integer>
+    <key>openTypeGaspRangeRecords</key>
+    <array>
+      <dict>
+        <key>rangeGaspBehavior</key>
+        <array>
+          <integer>1</integer>
+          <integer>3</integer>
+        </array>
+        <key>rangeMaxPPEM</key>
+        <integer>9</integer>
+      </dict>
+      <dict>
+        <key>rangeGaspBehavior</key>
+        <array>
+          <integer>0</integer>
+          <integer>1</integer>
+          <integer>2</integer>
+          <integer>3</integer>
+        </array>
+        <key>rangeMaxPPEM</key>
+        <integer>50</integer>
+      </dict>
+      <dict>
+        <key>rangeGaspBehavior</key>
+        <array>
+          <integer>1</integer>
+          <integer>3</integer>
+        </array>
+        <key>rangeMaxPPEM</key>
+        <integer>65535</integer>
+      </dict>
+    </array>
     <key>openTypeHeadCreated</key>
     <string>2019/04/07 17:18:29</string>
+    <key>openTypeHheaAscender</key>
+    <integer>1900</integer>
+    <key>openTypeHheaDescender</key>
+    <integer>-480</integer>
+    <key>openTypeHheaLineGap</key>
+    <integer>0</integer>
     <key>openTypeNameDesigner</key>
     <string>Aaron Bell</string>
     <key>openTypeNameDesignerURL</key>
@@ -214,8 +252,18 @@ THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
     </array>
     <key>openTypeOS2Type</key>
     <array/>
+    <key>openTypeOS2TypoAscender</key>
+    <integer>1900</integer>
+    <key>openTypeOS2TypoDescender</key>
+    <integer>-480</integer>
+    <key>openTypeOS2TypoLineGap</key>
+    <integer>0</integer>
     <key>openTypeOS2VendorID</key>
     <string>SAJA</string>
+    <key>openTypeOS2WinAscent</key>
+    <integer>2226</integer>
+    <key>openTypeOS2WinDescent</key>
+    <integer>480</integer>
     <key>postscriptBlueValues</key>
     <array>
       <integer>-20</integer>
@@ -265,9 +313,9 @@ THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
     <key>unitsPerEm</key>
     <integer>2048</integer>
     <key>versionMajor</key>
-    <integer>4</integer>
+    <integer>2007</integer>
     <key>versionMinor</key>
-    <integer>300</integer>
+    <integer>1</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/CascadiaCode-ExtraLight.ufo/fontinfo.plist
+++ b/sources/CascadiaCode-ExtraLight.ufo/fontinfo.plist
@@ -165,8 +165,46 @@
     </array>
     <key>italicAngle</key>
     <integer>0</integer>
+    <key>openTypeGaspRangeRecords</key>
+    <array>
+      <dict>
+        <key>rangeGaspBehavior</key>
+        <array>
+          <integer>1</integer>
+          <integer>3</integer>
+        </array>
+        <key>rangeMaxPPEM</key>
+        <integer>9</integer>
+      </dict>
+      <dict>
+        <key>rangeGaspBehavior</key>
+        <array>
+          <integer>0</integer>
+          <integer>1</integer>
+          <integer>2</integer>
+          <integer>3</integer>
+        </array>
+        <key>rangeMaxPPEM</key>
+        <integer>50</integer>
+      </dict>
+      <dict>
+        <key>rangeGaspBehavior</key>
+        <array>
+          <integer>1</integer>
+          <integer>3</integer>
+        </array>
+        <key>rangeMaxPPEM</key>
+        <integer>65535</integer>
+      </dict>
+    </array>
     <key>openTypeHeadCreated</key>
     <string>2019/04/07 17:18:29</string>
+    <key>openTypeHheaAscender</key>
+    <integer>1900</integer>
+    <key>openTypeHheaDescender</key>
+    <integer>-480</integer>
+    <key>openTypeHheaLineGap</key>
+    <integer>0</integer>
     <key>openTypeNameDesigner</key>
     <string>Aaron Bell</string>
     <key>openTypeNameDesignerURL</key>
@@ -214,8 +252,18 @@ THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
     </array>
     <key>openTypeOS2Type</key>
     <array/>
+    <key>openTypeOS2TypoAscender</key>
+    <integer>1900</integer>
+    <key>openTypeOS2TypoDescender</key>
+    <integer>-480</integer>
+    <key>openTypeOS2TypoLineGap</key>
+    <integer>0</integer>
     <key>openTypeOS2VendorID</key>
     <string>SAJA</string>
+    <key>openTypeOS2WinAscent</key>
+    <integer>2226</integer>
+    <key>openTypeOS2WinDescent</key>
+    <integer>480</integer>
     <key>postscriptBlueValues</key>
     <array>
       <integer>-20</integer>
@@ -265,9 +313,9 @@ THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
     <key>unitsPerEm</key>
     <integer>2048</integer>
     <key>versionMajor</key>
-    <integer>4</integer>
+    <integer>2007</integer>
     <key>versionMinor</key>
-    <integer>300</integer>
+    <integer>1</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/CascadiaCode-Regular.ufo/fontinfo.plist
+++ b/sources/CascadiaCode-Regular.ufo/fontinfo.plist
@@ -165,8 +165,46 @@
     </array>
     <key>italicAngle</key>
     <integer>0</integer>
+    <key>openTypeGaspRangeRecords</key>
+    <array>
+      <dict>
+        <key>rangeGaspBehavior</key>
+        <array>
+          <integer>1</integer>
+          <integer>3</integer>
+        </array>
+        <key>rangeMaxPPEM</key>
+        <integer>9</integer>
+      </dict>
+      <dict>
+        <key>rangeGaspBehavior</key>
+        <array>
+          <integer>0</integer>
+          <integer>1</integer>
+          <integer>2</integer>
+          <integer>3</integer>
+        </array>
+        <key>rangeMaxPPEM</key>
+        <integer>50</integer>
+      </dict>
+      <dict>
+        <key>rangeGaspBehavior</key>
+        <array>
+          <integer>1</integer>
+          <integer>3</integer>
+        </array>
+        <key>rangeMaxPPEM</key>
+        <integer>65535</integer>
+      </dict>
+    </array>
     <key>openTypeHeadCreated</key>
     <string>2019/04/07 17:18:29</string>
+    <key>openTypeHheaAscender</key>
+    <integer>1900</integer>
+    <key>openTypeHheaDescender</key>
+    <integer>-480</integer>
+    <key>openTypeHheaLineGap</key>
+    <integer>0</integer>
     <key>openTypeNameDesigner</key>
     <string>Aaron Bell</string>
     <key>openTypeNameDesignerURL</key>
@@ -214,8 +252,18 @@ THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
     </array>
     <key>openTypeOS2Type</key>
     <array/>
+    <key>openTypeOS2TypoAscender</key>
+    <integer>1900</integer>
+    <key>openTypeOS2TypoDescender</key>
+    <integer>-480</integer>
+    <key>openTypeOS2TypoLineGap</key>
+    <integer>0</integer>
     <key>openTypeOS2VendorID</key>
     <string>SAJA</string>
+    <key>openTypeOS2WinAscent</key>
+    <integer>2226</integer>
+    <key>openTypeOS2WinDescent</key>
+    <integer>480</integer>
     <key>postscriptBlueValues</key>
     <array>
       <integer>-20</integer>
@@ -265,9 +313,9 @@ THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
     <key>unitsPerEm</key>
     <integer>2048</integer>
     <key>versionMajor</key>
-    <integer>4</integer>
+    <integer>2007</integer>
     <key>versionMinor</key>
-    <integer>300</integer>
+    <integer>1</integer>
     <key>xHeight</key>
     <integer>1060</integer>
   </dict>

--- a/sources/CascadiaCode.designspace
+++ b/sources/CascadiaCode.designspace
@@ -44,47 +44,179 @@
     </source>
   </sources>
   <instances>
-    <instance name="Cascadia Code ExtraLight" familyname="Cascadia Code" stylename="ExtraLight" filename="instance_ufos/CascadiaCode-ExtraLight.ufo" stylemapfamilyname="Cascadia Code ExtraLight" stylemapstylename="regular">
+    <instance name="Cascadia Code ExtraLight" familyname="Cascadia Code" stylename="ExtraLight" filename="../build/instance_ufos/CascadiaCode-ExtraLight.ufo" stylemapfamilyname="Cascadia Code ExtraLight" stylemapstylename="regular">
       <location>
         <dimension name="Weight" xvalue="140"/>
       </location>
       <kerning/>
       <info/>
+      <lib>
+        <dict>
+          <key>com.schriftgestaltung.customParameters</key>
+          <array>
+            <array>
+              <string>panose</string>
+              <array>
+                <integer>2</integer>
+                <integer>11</integer>
+                <integer>6</integer>
+                <integer>9</integer>
+                <integer>2</integer>
+                <integer>0</integer>
+                <integer>0</integer>
+                <integer>2</integer>
+                <integer>0</integer>
+                <integer>4</integer>
+              </array>
+            </array>
+          </array>
+        </dict>
+      </lib>
     </instance>
-    <instance name="Cascadia Code Light" familyname="Cascadia Code" stylename="Light" filename="instance_ufos/CascadiaCode-Light.ufo" stylemapfamilyname="Cascadia Code Light" stylemapstylename="regular">
+    <instance name="Cascadia Code Light" familyname="Cascadia Code" stylename="Light" filename="../build/instance_ufos/CascadiaCode-Light.ufo" stylemapfamilyname="Cascadia Code Light" stylemapstylename="regular">
       <location>
         <dimension name="Weight" xvalue="260"/>
       </location>
       <kerning/>
       <info/>
+      <lib>
+        <dict>
+          <key>com.schriftgestaltung.customParameters</key>
+          <array>
+            <array>
+              <string>panose</string>
+              <array>
+                <integer>2</integer>
+                <integer>11</integer>
+                <integer>6</integer>
+                <integer>9</integer>
+                <integer>2</integer>
+                <integer>0</integer>
+                <integer>0</integer>
+                <integer>2</integer>
+                <integer>0</integer>
+                <integer>4</integer>
+              </array>
+            </array>
+          </array>
+        </dict>
+      </lib>
     </instance>
-    <instance name="Cascadia Code SemiLight" familyname="Cascadia Code" stylename="SemiLight" filename="instance_ufos/CascadiaCode-SemiLight.ufo" stylemapfamilyname="Cascadia Code SemiLight" stylemapstylename="regular">
+    <instance name="Cascadia Code SemiLight" familyname="Cascadia Code" stylename="SemiLight" filename="../build/instance_ufos/CascadiaCode-SemiLight.ufo" stylemapfamilyname="Cascadia Code SemiLight" stylemapstylename="regular">
       <location>
         <dimension name="Weight" xvalue="380"/>
       </location>
       <kerning/>
       <info/>
+      <lib>
+        <dict>
+          <key>com.schriftgestaltung.customParameters</key>
+          <array>
+            <array>
+              <string>panose</string>
+              <array>
+                <integer>2</integer>
+                <integer>11</integer>
+                <integer>6</integer>
+                <integer>9</integer>
+                <integer>2</integer>
+                <integer>0</integer>
+                <integer>0</integer>
+                <integer>2</integer>
+                <integer>0</integer>
+                <integer>4</integer>
+              </array>
+            </array>
+          </array>
+        </dict>
+      </lib>
     </instance>
-    <instance name="Cascadia Code Regular" familyname="Cascadia Code" stylename="Regular" filename="instance_ufos/CascadiaCode-Regular.ufo" stylemapfamilyname="Cascadia Code" stylemapstylename="regular">
+    <instance name="Cascadia Code Regular" familyname="Cascadia Code" stylename="Regular" filename="../build/instance_ufos/CascadiaCode-Regular.ufo" stylemapfamilyname="Cascadia Code" stylemapstylename="regular">
       <location>
         <dimension name="Weight" xvalue="500"/>
       </location>
       <kerning/>
       <info/>
+      <lib>
+        <dict>
+          <key>com.schriftgestaltung.customParameters</key>
+          <array>
+            <array>
+              <string>panose</string>
+              <array>
+                <integer>2</integer>
+                <integer>11</integer>
+                <integer>6</integer>
+                <integer>9</integer>
+                <integer>2</integer>
+                <integer>0</integer>
+                <integer>0</integer>
+                <integer>2</integer>
+                <integer>0</integer>
+                <integer>4</integer>
+              </array>
+            </array>
+          </array>
+        </dict>
+      </lib>
     </instance>
-    <instance name="Cascadia Code SemiBold" familyname="Cascadia Code" stylename="SemiBold" filename="instance_ufos/CascadiaCode-SemiBold.ufo" stylemapfamilyname="Cascadia Code SemiBold" stylemapstylename="regular">
+    <instance name="Cascadia Code SemiBold" familyname="Cascadia Code" stylename="SemiBold" filename="../build/instance_ufos/CascadiaCode-SemiBold.ufo" stylemapfamilyname="Cascadia Code SemiBold" stylemapstylename="regular">
       <location>
         <dimension name="Weight" xvalue="650"/>
       </location>
       <kerning/>
       <info/>
+      <lib>
+        <dict>
+          <key>com.schriftgestaltung.customParameters</key>
+          <array>
+            <array>
+              <string>panose</string>
+              <array>
+                <integer>2</integer>
+                <integer>11</integer>
+                <integer>6</integer>
+                <integer>9</integer>
+                <integer>2</integer>
+                <integer>0</integer>
+                <integer>0</integer>
+                <integer>2</integer>
+                <integer>0</integer>
+                <integer>4</integer>
+              </array>
+            </array>
+          </array>
+        </dict>
+      </lib>
     </instance>
-    <instance name="Cascadia Code Bold" familyname="Cascadia Code" stylename="Bold" filename="instance_ufos/CascadiaCode-Bold.ufo" stylemapfamilyname="Cascadia Code" stylemapstylename="bold">
+    <instance name="Cascadia Code Bold" familyname="Cascadia Code" stylename="Bold" filename="../build/instance_ufos/CascadiaCode-Bold.ufo" stylemapfamilyname="Cascadia Code" stylemapstylename="bold">
       <location>
         <dimension name="Weight" xvalue="750"/>
       </location>
       <kerning/>
       <info/>
+      <lib>
+        <dict>
+          <key>com.schriftgestaltung.customParameters</key>
+          <array>
+            <array>
+              <string>panose</string>
+              <array>
+                <integer>2</integer>
+                <integer>11</integer>
+                <integer>6</integer>
+                <integer>9</integer>
+                <integer>2</integer>
+                <integer>0</integer>
+                <integer>0</integer>
+                <integer>2</integer>
+                <integer>0</integer>
+                <integer>4</integer>
+              </array>
+            </array>
+          </array>
+        </dict>
+      </lib>
     </instance>
   </instances>
   <lib>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What character(s) are you changing/creating and how was it tested (even manually, if necessary)? Did you hint the entire font or only the modified character(s)? -->
## Summary of the Pull Request

1. Make static fonts on CI for proper coverage.
2. Move metadata from build.py into the actual sources. Some parameters (e.g. PANOSE) you can set in Glyphs but not a Designspace can be applied anyway with glyphsLib.
3. Disable variable OTF generation due to https://github.com/adobe-type-tools/psautohint/issues/40.
4. Remove a dead function call `step_remove_ligatures` from build.py
5. Simplify static and variable font generation a bit by generating instances once and fully loading a Designspace for variables once. Each production step then gets a copy.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Requires FONTLOG.txt to be updated
* [ ] Requires [/images/cascadia-code.png](/microsoft/cascadia-code/blob/master/images/cascadia-code.png) and/or [/images/cascadia-code-characters.png](/microsoft/cascadia-code/blob/master/images/cascadia-code-characters.png) to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. List steps that were taken. -->
## Validation Steps Performed

CI build.