### PR TITLE
Set the names of the static instances properly

### DIFF
--- a/build.py
+++ b/build.py
@@ -218,7 +218,7 @@ def compile_static_and_save(instance: ufoLib2.Font, name:str) -> None:
         optimizeCFF=ufo2ft.CFFOptimization.NONE,
     )
 
-    file_name = name.replace(" ", "") + "-"  + instance.info.styleName
+    file_name = f"{family_name}-{style_name}".replace(" ", "")
     file_path_static = (OUTPUT_STATIC_TTF_DIR / file_name).with_suffix(".ttf")
     file_path_static_otf = (OUTPUT_STATIC_OTF_DIR / file_name).with_suffix(".otf")
 

--- a/build.py
+++ b/build.py
@@ -39,10 +39,10 @@ NERDFONTS_DIR = INPUT_DIR / "nerdfonts"
 
 
 def step_set_font_name(name: str, source: ufoLib2.Font) -> None:
-    source.info.familyName = name
+    source.info.familyName = source.info.familyName.replace("Cascadia Code", name)
     # We have to change the style map family name because that's what
     # Windows uses to map Bold/Regular/Medium/etc. fonts
-    source.info.styleMapFamilyName = name
+    source.info.styleMapFamilyName = source.info.styleMapFamilyName.replace("Cascadia Code", name)
 
 
 def step_merge_glyphs_from_ufo(path: Path, instance: ufoLib2.Font) -> None:
@@ -122,8 +122,9 @@ def prepare_fonts(
             print("Variant name not identified. Please check.")
         set_font_metaData(source.font)
     for instance in designspace.instances:
-            instance.familyName = name
-            instance.styleMapFamilyName = name
+        instance.name = instance.name.replace("Cascadia Code", name)
+        instance.familyName = instance.familyName.replace("Cascadia Code", name)
+        instance.styleMapFamilyName = instance.styleMapFamilyName.replace("Cascadia Code", name)
 
 
 def to_woff2(source_path: Path, target_path: Path) -> None:
@@ -155,7 +156,7 @@ def build_font_static(
     prepare_fonts(designspace, name)
     generator = fontmake.instantiator.Instantiator.from_designspace(designspace)
     instance = generator.generate_instance(instance_descriptor)
-    compile_static_and_save(instance)
+    compile_static_and_save(instance, name)
 
 
 # Export fonts
@@ -196,8 +197,8 @@ def compile_variable_and_save(
     print(f"[{familyName}] Done: {file_path}")
 
 
-def compile_static_and_save(instance: ufoLib2.Font) -> None:
-    family_name = instance.info.familyName
+def compile_static_and_save(instance: ufoLib2.Font, name:str) -> None:
+    family_name = name
     style_name = instance.info.styleName
     print(f"[{family_name}] Building static instance: {style_name}")
 
@@ -217,7 +218,7 @@ def compile_static_and_save(instance: ufoLib2.Font) -> None:
         optimizeCFF=ufo2ft.CFFOptimization.NONE,
     )
 
-    file_name = f"{family_name}-{style_name}".replace(" ", "")
+    file_name = name.replace(" ", "") + "-"  + instance.info.styleName
     file_path_static = (OUTPUT_STATIC_TTF_DIR / file_name).with_suffix(".ttf")
     file_path_static_otf = (OUTPUT_STATIC_OTF_DIR / file_name).with_suffix(".otf")
 

--- a/build.py
+++ b/build.py
@@ -38,11 +38,11 @@ NERDFONTS_DIR = INPUT_DIR / "nerdfonts"
 # ****************************************************************
 
 
-def step_set_font_name(name: str, instance: ufoLib2.Font) -> None:
-    instance.info.familyName = name
+def step_set_font_name(name: str, source: ufoLib2.Font) -> None:
+    source.info.familyName = name
     # We have to change the style map family name because that's what
     # Windows uses to map Bold/Regular/Medium/etc. fonts
-    instance.info.styleMapFamilyName = name
+    source.info.styleMapFamilyName = name
 
 
 def step_merge_glyphs_from_ufo(path: Path, instance: ufoLib2.Font) -> None:
@@ -121,6 +121,9 @@ def prepare_fonts(
         else:
             print("Variant name not identified. Please check.")
         set_font_metaData(source.font)
+    for instance in designspace.instances:
+            instance.familyName = name
+            instance.styleMapFamilyName = name
 
 
 def to_woff2(source_path: Path, target_path: Path) -> None:
@@ -152,7 +155,6 @@ def build_font_static(
     prepare_fonts(designspace, name)
     generator = fontmake.instantiator.Instantiator.from_designspace(designspace)
     instance = generator.generate_instance(instance_descriptor)
-    step_set_font_name(name, instance)
     compile_static_and_save(instance)
 
 


### PR DESCRIPTION
## Summary of the Pull Request

Now builds static instances correctly. 

## PR Checklist
* [x] Closes #369
* [x] CLA signed.

## Detailed Description of the Pull Request / Additional comments

As far as I can tell, what essentially happened here is that _instances_ in the designspace were not being renamed, even though the sources were being renamed. As a result, the variable fonts would build correctly, but the static instances were not. The font naming approach has now been changed and is producing reliable results. 

What's particularly vexing is that for the life of me I can't figure out how the code actually worked before, because as far as I can tell, we've _never_ modified the instance code before.

## Validation Steps Performed
Checked tables in OT Master