### PR TITLE
Help VS users get the best font rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Once unzipped, right-click the font file and click "Install for all users". This
 
 For more details and app-specific instructions, [please check the wiki](https://github.com/microsoft/cascadia-code/wiki/Installing-Cascadia-Code). 
 
+**Visual Studio users:** Cascadia Code looks much better in the editor after setting this option: Tools->Options->Text Editor->Advanced->Text formatting method->Ideal.
+
 # Get involved
 Instructions on how to modify and submit an update to the Cascadia Code source is [available in the wiki](https://github.com/microsoft/cascadia-code/wiki/Modifying-Cascadia-Code).
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Once unzipped, right-click the font file and click "Install for all users". This
 
 For more details and app-specific instructions, [please check the wiki](https://github.com/microsoft/cascadia-code/wiki/Installing-Cascadia-Code). 
 
-**Visual Studio users:** Cascadia Code looks much better in the editor after setting this option: Tools->Options->Text Editor->Advanced->Text formatting method->Ideal.
+**Visual Studio users:** Cascadia Code may look better in the editor after setting this option: Tools->Options->Text Editor->Advanced->Text formatting method->Ideal. This may not be necessary on high DPI screens.
 
 # Get involved
 Instructions on how to modify and submit an update to the Cascadia Code source is [available in the wiki](https://github.com/microsoft/cascadia-code/wiki/Modifying-Cascadia-Code).


### PR DESCRIPTION
Cascadia Code looks pretty bad in the VS editor under default settings. To help ensure developers see the font in the best rendering, this change to the README helps users realize it can look much better.

**BEFORE**

![image](https://user-images.githubusercontent.com/3548/107530833-77335600-6b79-11eb-8f6d-e7376f67c0bc.png)

**AFTER**

![image](https://user-images.githubusercontent.com/3548/107530744-6aaefd80-6b79-11eb-9d8b-c3dfe49ff1b9.png)
