### PR TITLE
Updating build script to remove unnecessary "Italic" from static instances

### DIFF
--- a/build.py
+++ b/build.py
@@ -202,9 +202,13 @@ def build_font_static(
     name: str,
 ) -> None:
     prepare_fonts(designspace, name)
+
     generator = fontmake.instantiator.Instantiator.from_designspace(designspace)
     instance = generator.generate_instance(instance_descriptor)
-    compile_static_and_save(instance, name)
+    instance.info.familyName = instance.info.familyName.replace(" Italic","")
+    if instance.info.styleMapFamilyName:
+        instance.info.styleMapFamilyName = instance.info.styleMapFamilyName.replace(" Italic","")
+    compile_static_and_save(instance, name.replace(" Italic",""))
 
 
 # Export fonts


### PR DESCRIPTION
## Summary of the Pull Request
Removes the unnecessary "Italic" from the static instances. 

## PR Checklist
* [x] Closes #465

## Detailed Description of the Pull Request / Additional comments
For whatever reason glyphslib sets the familyName of the font to include the "Italic" name. I set the variable font instance, but not the static instances. This has been corrected, and all static instances are building as expected now. 
