### PR TITLE
Add macOS to list of TTF  hinting supported OSes in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The variants contained within are:
 -  `Cascadia Mono`: a version of Cascadia that doesn't have ligatures
 -  `Cascadia (Code|Mono) PL`: a version of Cascadia that has embedded Powerline symbols
 
-For optimal rendering quality, we recommend using the TTF version on Windows and any other OS that employs TrueType hinting. For more information on different font formats, [please check the wiki](https://github.com/microsoft/cascadia-code/wiki/Installing-Cascadia-Code).
+For optimal rendering quality, we recommend using the TTF version on Windows, macOS and any other OS that employs TrueType hinting. For more information on different font formats, [please check the wiki](https://github.com/microsoft/cascadia-code/wiki/Installing-Cascadia-Code).
 
 Once unzipped, right-click the font file and click "Install for all users". This will install the font onto your machine. 
 


### PR DESCRIPTION
Explicitly add macOS due to significant userbase.

<!-- Enter a brief description/summary of your PR here. What character(s) are you changing/creating and how was it tested (even manually, if necessary)? Did you hint the entire font or only the modified character(s)? -->
## Summary of the Pull Request

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Requires FONTLOG.txt to be updated
* [ ] Requires [/images/cascadia-code.png](/microsoft/cascadia-code/blob/main/images/cascadia-code.png) and/or [/images/cascadia-code-characters.png](/microsoft/cascadia-code/blob/main/images/cascadia-code-characters.png) to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Provide images of the character(s) that are being modified/created at different screen sizes. Clearly identifying specific code points is heavily recommended. -->
## Before (if applicable) and After Images of the Character(s)

<!-- Describe how you validated the behavior. List steps that were taken. -->
## Validation Steps Performed
