### PR TITLE
Don't leak an open file handle; fix Pyling R1732

### DIFF
--- a/build.py
+++ b/build.py
@@ -572,7 +572,8 @@ if __name__ == "__main__":
     # Step 1.5: Adding STAT tables in one go
     print ("[Cascadia Variable fonts] Fixing STAT tables")
     fontSTAT = [fontTools.ttLib.TTFont(f) for f in list(OUTPUT_TTF_DIR.glob("*.ttf"))]
-    config = yaml.load(open(INPUT_DIR/"stat.yaml"), Loader=yaml.SafeLoader)
+    with open(INPUT_DIR/"stat.yaml") as f:
+        config = yaml.load(f, Loader=yaml.SafeLoader)
     gen_stat_tables_from_config(config, fontSTAT)
 
     for font in fontSTAT:


### PR DESCRIPTION
**The problem**
The code had a case of a manual file handler pitfall, where a resource stream is opened manually and never closed.

This pitfall was detected using Pyling, which triggered a massage of code R1732 with the message  "Consider using 'with' for resource-allocating operations"

**The solution**
Used a 'with' block to automatically close the open stream on the file just after it is no longer needed