### PR TITLE
fix(sec): upgrade lxml to 4.9.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -104,7 +104,7 @@ itsdangerous==2.0.1
     # via flask
 jinja2==3.0.1
     # via flask
-lxml==4.6.3
+lxml==4.9.1
     # via fonttools
 markupsafe==2.0.1
     # via jinja2


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in lxml 4.6.3
- [CVE-2022-2309](https://www.oscs1024.com/hd/CVE-2022-2309)


### What did I do？
Upgrade lxml from 4.6.3 to 4.9.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS