### PR TITLE
fix(sec): upgrade pyjwt to 2.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -136,7 +136,7 @@ pygit2==1.6.1
     # via gftools
 pygithub==1.55
     # via gftools
-pyjwt==2.1.0
+pyjwt==2.4.0
     # via pygithub
 pynacl==1.4.0
     # via pygithub


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in pyjwt 2.1.0
- [CVE-2022-29217](https://www.oscs1024.com/hd/CVE-2022-29217)


### What did I do？
Upgrade pyjwt from 2.1.0 to 2.4.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS