### PR TITLE
fix(sec): upgrade werkzeug to 2.2.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -195,7 +195,7 @@ vttlib==0.11.0
     #   gftools
 vttmisc==0.0.5
     # via -r requirements.in
-werkzeug==2.0.1
+werkzeug==2.2.3
     # via flask
 wrapt==1.12.1
     # via deprecated


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in werkzeug 2.0.1
- [CVE-2023-23934](https://www.oscs1024.com/hd/CVE-2023-23934)


### What did I do？
Upgrade werkzeug from 2.0.1 to 2.2.3 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS
Signed-off-by:pen4948453219@qq.com