### PR TITLE
fix(sec): upgrade certifi to 2022.12.07

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ browserstack-local==1.2.2
     # via gftools
 cattrs==1.7.1
     # via statmake
-certifi==2021.5.30
+certifi==2022.12.07
     # via requests
 cffi==1.14.6
     # via


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in certifi 2021.5.30
- [CVE-2022-23491](https://www.oscs1024.com/hd/CVE-2022-23491)


### What did I do？
Upgrade certifi from 2021.5.30 to 2022.12.07 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS