### PR TITLE
Adjusting half-blocks, quadrants,... coordinates to unify mosaics

### DIFF
--- a/sources/CascadiaCode-Bold.ufo/glyphs/lowerO_neE_ighthB_lock.stypo.glif
+++ b/sources/CascadiaCode-Bold.ufo/glyphs/lowerO_neE_ighthB_lock.stypo.glif
@@ -5,8 +5,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="-183" type="line"/>
-      <point x="0" y="-183" type="line"/>
+      <point x="1200" y="-182" type="line"/>
+      <point x="0" y="-182" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-Bold.ufo/glyphs/lowerR_ightB_lock.glif
+++ b/sources/CascadiaCode-Bold.ufo/glyphs/lowerR_ightB_lock.glif
@@ -6,8 +6,8 @@
     <contour>
       <point x="600" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="1200" y="873" type="line"/>
+      <point x="600" y="873" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-Bold.ufo/glyphs/lowerR_ightB_lock.stypo.glif
+++ b/sources/CascadiaCode-Bold.ufo/glyphs/lowerR_ightB_lock.stypo.glif
@@ -5,8 +5,8 @@
     <contour>
       <point x="600" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="1200" y="710" type="line"/>
+      <point x="600" y="710" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-Bold.ufo/glyphs/lowerS_evenE_ighthsB_lock.glif
+++ b/sources/CascadiaCode-Bold.ufo/glyphs/lowerS_evenE_ighthsB_lock.glif
@@ -6,8 +6,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="1887" type="line"/>
-      <point x="0" y="1887" type="line"/>
+      <point x="1200" y="1888" type="line"/>
+      <point x="0" y="1888" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-Bold.ufo/glyphs/lowerT_hreeE_ighthsB_lock.glif
+++ b/sources/CascadiaCode-Bold.ufo/glyphs/lowerT_hreeE_ighthsB_lock.glif
@@ -6,8 +6,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="534" type="line"/>
-      <point x="0" y="534" type="line"/>
+      <point x="1200" y="535" type="line"/>
+      <point x="0" y="535" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-Bold.ufo/glyphs/upperH_alfB_lock.glif
+++ b/sources/CascadiaCode-Bold.ufo/glyphs/upperH_alfB_lock.glif
@@ -4,8 +4,8 @@
   <unicode hex="2580"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="0" y="873" type="line"/>
+      <point x="1200" y="873" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
     </contour>

--- a/sources/CascadiaCode-Bold.ufo/glyphs/upperH_alfB_lock.stypo.glif
+++ b/sources/CascadiaCode-Bold.ufo/glyphs/upperH_alfB_lock.stypo.glif
@@ -3,8 +3,8 @@
   <advance width="1200"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="0" y="710" type="line"/>
+      <point x="1200" y="710" type="line"/>
       <point x="1200" y="1900" type="line"/>
       <point x="0" y="1900" type="line"/>
     </contour>

--- a/sources/CascadiaCode-Bold.ufo/glyphs/upperL_eftA_ndL_owerR_ightB_lock.glif
+++ b/sources/CascadiaCode-Bold.ufo/glyphs/upperL_eftA_ndL_owerR_ightB_lock.glif
@@ -4,16 +4,16 @@
   <unicode hex="259A"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="873" type="line"/>
+      <point x="600" y="873" type="line"/>
       <point x="600" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
     </contour>
     <contour>
       <point x="600" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="1200" y="873" type="line"/>
+      <point x="600" y="873" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-Bold.ufo/glyphs/upperL_eftA_ndL_owerR_ightB_lock.stypo.glif
+++ b/sources/CascadiaCode-Bold.ufo/glyphs/upperL_eftA_ndL_owerR_ightB_lock.stypo.glif
@@ -3,16 +3,16 @@
   <advance width="1200"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="710" type="line"/>
+      <point x="600" y="710" type="line"/>
       <point x="600" y="1900" type="line"/>
       <point x="0" y="1900" type="line"/>
     </contour>
     <contour>
       <point x="600" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="1200" y="710" type="line"/>
+      <point x="600" y="710" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-Bold.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerL_eftB_lock.glif
+++ b/sources/CascadiaCode-Bold.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerL_eftB_lock.glif
@@ -6,8 +6,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="600" y="-480" type="line"/>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="873" type="line"/>
+      <point x="1200" y="873" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
     </contour>

--- a/sources/CascadiaCode-Bold.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerL_eftB_lock.stypo.glif
+++ b/sources/CascadiaCode-Bold.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerL_eftB_lock.stypo.glif
@@ -5,8 +5,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="600" y="-480" type="line"/>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="710" type="line"/>
+      <point x="1200" y="710" type="line"/>
       <point x="1200" y="1900" type="line"/>
       <point x="0" y="1900" type="line"/>
     </contour>

--- a/sources/CascadiaCode-Bold.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerR_ightB_lock.glif
+++ b/sources/CascadiaCode-Bold.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerR_ightB_lock.glif
@@ -8,8 +8,8 @@
       <point x="1200" y="-480" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="873" type="line"/>
+      <point x="600" y="873" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-Bold.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerR_ightB_lock.stypo.glif
+++ b/sources/CascadiaCode-Bold.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerR_ightB_lock.stypo.glif
@@ -7,8 +7,8 @@
       <point x="1200" y="-480" type="line"/>
       <point x="1200" y="1900" type="line"/>
       <point x="0" y="1900" type="line"/>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="710" type="line"/>
+      <point x="600" y="710" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-Bold.ufo/glyphs/upperL_eftB_lock.glif
+++ b/sources/CascadiaCode-Bold.ufo/glyphs/upperL_eftB_lock.glif
@@ -4,8 +4,8 @@
   <unicode hex="2598"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="873" type="line"/>
+      <point x="600" y="873" type="line"/>
       <point x="600" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
     </contour>

--- a/sources/CascadiaCode-Bold.ufo/glyphs/upperL_eftB_lock.stypo.glif
+++ b/sources/CascadiaCode-Bold.ufo/glyphs/upperL_eftB_lock.stypo.glif
@@ -3,8 +3,8 @@
   <advance width="1200"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="710" type="line"/>
+      <point x="600" y="710" type="line"/>
       <point x="600" y="1900" type="line"/>
       <point x="0" y="1900" type="line"/>
     </contour>

--- a/sources/CascadiaCode-Bold.ufo/glyphs/upperO_neE_ighthB_lock.glif
+++ b/sources/CascadiaCode-Bold.ufo/glyphs/upperO_neE_ighthB_lock.glif
@@ -4,8 +4,8 @@
   <unicode hex="2594"/>
   <outline>
     <contour>
-      <point x="0" y="1887" type="line"/>
-      <point x="1200" y="1887" type="line"/>
+      <point x="0" y="1888" type="line"/>
+      <point x="1200" y="1888" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
     </contour>

--- a/sources/CascadiaCode-Bold.ufo/glyphs/upperR_ightA_ndL_owerL_eftB_lock.glif
+++ b/sources/CascadiaCode-Bold.ufo/glyphs/upperR_ightA_ndL_owerL_eftB_lock.glif
@@ -6,8 +6,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="600" y="-480" type="line"/>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="873" type="line"/>
+      <point x="1200" y="873" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="600" y="2226" type="line"/>
       <point x="600" y="873" type="line"/>

--- a/sources/CascadiaCode-Bold.ufo/glyphs/upperR_ightA_ndL_owerL_eftB_lock.stypo.glif
+++ b/sources/CascadiaCode-Bold.ufo/glyphs/upperR_ightA_ndL_owerL_eftB_lock.stypo.glif
@@ -5,8 +5,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="600" y="-480" type="line"/>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="710" type="line"/>
+      <point x="1200" y="710" type="line"/>
       <point x="1200" y="1900" type="line"/>
       <point x="600" y="1900" type="line"/>
       <point x="600" y="710" type="line"/>

--- a/sources/CascadiaCode-Bold.ufo/glyphs/upperR_ightB_lock.glif
+++ b/sources/CascadiaCode-Bold.ufo/glyphs/upperR_ightB_lock.glif
@@ -4,8 +4,8 @@
   <unicode hex="259D"/>
   <outline>
     <contour>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="873" type="line"/>
+      <point x="1200" y="873" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="600" y="2226" type="line"/>
     </contour>

--- a/sources/CascadiaCode-Bold.ufo/glyphs/upperR_ightB_lock.stypo.glif
+++ b/sources/CascadiaCode-Bold.ufo/glyphs/upperR_ightB_lock.stypo.glif
@@ -3,8 +3,8 @@
   <advance width="1200"/>
   <outline>
     <contour>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="710" type="line"/>
+      <point x="1200" y="710" type="line"/>
       <point x="1200" y="1900" type="line"/>
       <point x="600" y="1900" type="line"/>
     </contour>

--- a/sources/CascadiaCode-BoldItalic.ufo/glyphs/lowerO_neE_ighthB_lock.stypo.glif
+++ b/sources/CascadiaCode-BoldItalic.ufo/glyphs/lowerO_neE_ighthB_lock.stypo.glif
@@ -5,8 +5,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="-183" type="line"/>
-      <point x="0" y="-183" type="line"/>
+      <point x="1200" y="-182" type="line"/>
+      <point x="0" y="-182" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-BoldItalic.ufo/glyphs/lowerR_ightB_lock.glif
+++ b/sources/CascadiaCode-BoldItalic.ufo/glyphs/lowerR_ightB_lock.glif
@@ -6,8 +6,8 @@
     <contour>
       <point x="600" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="1200" y="873" type="line"/>
+      <point x="600" y="873" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-BoldItalic.ufo/glyphs/lowerR_ightB_lock.stypo.glif
+++ b/sources/CascadiaCode-BoldItalic.ufo/glyphs/lowerR_ightB_lock.stypo.glif
@@ -5,8 +5,8 @@
     <contour>
       <point x="600" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="1200" y="710" type="line"/>
+      <point x="600" y="710" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-BoldItalic.ufo/glyphs/lowerS_evenE_ighthsB_lock.glif
+++ b/sources/CascadiaCode-BoldItalic.ufo/glyphs/lowerS_evenE_ighthsB_lock.glif
@@ -6,8 +6,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="1887" type="line"/>
-      <point x="0" y="1887" type="line"/>
+      <point x="1200" y="1888" type="line"/>
+      <point x="0" y="1888" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-BoldItalic.ufo/glyphs/lowerT_hreeE_ighthsB_lock.glif
+++ b/sources/CascadiaCode-BoldItalic.ufo/glyphs/lowerT_hreeE_ighthsB_lock.glif
@@ -6,8 +6,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="534" type="line"/>
-      <point x="0" y="534" type="line"/>
+      <point x="1200" y="535" type="line"/>
+      <point x="0" y="535" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-BoldItalic.ufo/glyphs/upperH_alfB_lock.glif
+++ b/sources/CascadiaCode-BoldItalic.ufo/glyphs/upperH_alfB_lock.glif
@@ -4,8 +4,8 @@
   <unicode hex="2580"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="0" y="873" type="line"/>
+      <point x="1200" y="873" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
     </contour>

--- a/sources/CascadiaCode-BoldItalic.ufo/glyphs/upperH_alfB_lock.stypo.glif
+++ b/sources/CascadiaCode-BoldItalic.ufo/glyphs/upperH_alfB_lock.stypo.glif
@@ -3,8 +3,8 @@
   <advance width="1200"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="0" y="710" type="line"/>
+      <point x="1200" y="710" type="line"/>
       <point x="1200" y="1900" type="line"/>
       <point x="0" y="1900" type="line"/>
     </contour>

--- a/sources/CascadiaCode-BoldItalic.ufo/glyphs/upperL_eftA_ndL_owerR_ightB_lock.glif
+++ b/sources/CascadiaCode-BoldItalic.ufo/glyphs/upperL_eftA_ndL_owerR_ightB_lock.glif
@@ -4,16 +4,16 @@
   <unicode hex="259A"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="873" type="line"/>
+      <point x="600" y="873" type="line"/>
       <point x="600" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
     </contour>
     <contour>
       <point x="600" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="1200" y="873" type="line"/>
+      <point x="600" y="873" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-BoldItalic.ufo/glyphs/upperL_eftA_ndL_owerR_ightB_lock.stypo.glif
+++ b/sources/CascadiaCode-BoldItalic.ufo/glyphs/upperL_eftA_ndL_owerR_ightB_lock.stypo.glif
@@ -3,16 +3,16 @@
   <advance width="1200"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="710" type="line"/>
+      <point x="600" y="710" type="line"/>
       <point x="600" y="1900" type="line"/>
       <point x="0" y="1900" type="line"/>
     </contour>
     <contour>
       <point x="600" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="1200" y="710" type="line"/>
+      <point x="600" y="710" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-BoldItalic.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerL_eftB_lock.glif
+++ b/sources/CascadiaCode-BoldItalic.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerL_eftB_lock.glif
@@ -6,8 +6,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="600" y="-480" type="line"/>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="873" type="line"/>
+      <point x="1200" y="873" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
     </contour>

--- a/sources/CascadiaCode-BoldItalic.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerL_eftB_lock.stypo.glif
+++ b/sources/CascadiaCode-BoldItalic.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerL_eftB_lock.stypo.glif
@@ -5,8 +5,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="600" y="-480" type="line"/>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="710" type="line"/>
+      <point x="1200" y="710" type="line"/>
       <point x="1200" y="1900" type="line"/>
       <point x="0" y="1900" type="line"/>
     </contour>

--- a/sources/CascadiaCode-BoldItalic.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerR_ightB_lock.glif
+++ b/sources/CascadiaCode-BoldItalic.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerR_ightB_lock.glif
@@ -8,8 +8,8 @@
       <point x="1200" y="-480" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="873" type="line"/>
+      <point x="600" y="873" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-BoldItalic.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerR_ightB_lock.stypo.glif
+++ b/sources/CascadiaCode-BoldItalic.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerR_ightB_lock.stypo.glif
@@ -7,8 +7,8 @@
       <point x="1200" y="-480" type="line"/>
       <point x="1200" y="1900" type="line"/>
       <point x="0" y="1900" type="line"/>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="710" type="line"/>
+      <point x="600" y="710" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-BoldItalic.ufo/glyphs/upperL_eftB_lock.glif
+++ b/sources/CascadiaCode-BoldItalic.ufo/glyphs/upperL_eftB_lock.glif
@@ -4,8 +4,8 @@
   <unicode hex="2598"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="873" type="line"/>
+      <point x="600" y="873" type="line"/>
       <point x="600" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
     </contour>

--- a/sources/CascadiaCode-BoldItalic.ufo/glyphs/upperL_eftB_lock.stypo.glif
+++ b/sources/CascadiaCode-BoldItalic.ufo/glyphs/upperL_eftB_lock.stypo.glif
@@ -3,8 +3,8 @@
   <advance width="1200"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="710" type="line"/>
+      <point x="600" y="710" type="line"/>
       <point x="600" y="1900" type="line"/>
       <point x="0" y="1900" type="line"/>
     </contour>

--- a/sources/CascadiaCode-BoldItalic.ufo/glyphs/upperO_neE_ighthB_lock.glif
+++ b/sources/CascadiaCode-BoldItalic.ufo/glyphs/upperO_neE_ighthB_lock.glif
@@ -4,8 +4,8 @@
   <unicode hex="2594"/>
   <outline>
     <contour>
-      <point x="0" y="1887" type="line"/>
-      <point x="1200" y="1887" type="line"/>
+      <point x="0" y="1888" type="line"/>
+      <point x="1200" y="1888" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
     </contour>

--- a/sources/CascadiaCode-BoldItalic.ufo/glyphs/upperR_ightA_ndL_owerL_eftB_lock.glif
+++ b/sources/CascadiaCode-BoldItalic.ufo/glyphs/upperR_ightA_ndL_owerL_eftB_lock.glif
@@ -6,8 +6,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="600" y="-480" type="line"/>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="873" type="line"/>
+      <point x="1200" y="873" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="600" y="2226" type="line"/>
       <point x="600" y="873" type="line"/>

--- a/sources/CascadiaCode-BoldItalic.ufo/glyphs/upperR_ightA_ndL_owerL_eftB_lock.stypo.glif
+++ b/sources/CascadiaCode-BoldItalic.ufo/glyphs/upperR_ightA_ndL_owerL_eftB_lock.stypo.glif
@@ -5,8 +5,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="600" y="-480" type="line"/>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="710" type="line"/>
+      <point x="1200" y="710" type="line"/>
       <point x="1200" y="1900" type="line"/>
       <point x="600" y="1900" type="line"/>
       <point x="600" y="710" type="line"/>

--- a/sources/CascadiaCode-BoldItalic.ufo/glyphs/upperR_ightB_lock.glif
+++ b/sources/CascadiaCode-BoldItalic.ufo/glyphs/upperR_ightB_lock.glif
@@ -4,8 +4,8 @@
   <unicode hex="259D"/>
   <outline>
     <contour>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="873" type="line"/>
+      <point x="1200" y="873" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="600" y="2226" type="line"/>
     </contour>

--- a/sources/CascadiaCode-BoldItalic.ufo/glyphs/upperR_ightB_lock.stypo.glif
+++ b/sources/CascadiaCode-BoldItalic.ufo/glyphs/upperR_ightB_lock.stypo.glif
@@ -3,8 +3,8 @@
   <advance width="1200"/>
   <outline>
     <contour>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="710" type="line"/>
+      <point x="1200" y="710" type="line"/>
       <point x="1200" y="1900" type="line"/>
       <point x="600" y="1900" type="line"/>
     </contour>

--- a/sources/CascadiaCode-ExtraLight.ufo/glyphs/lowerO_neE_ighthB_lock.stypo.glif
+++ b/sources/CascadiaCode-ExtraLight.ufo/glyphs/lowerO_neE_ighthB_lock.stypo.glif
@@ -5,8 +5,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="-183" type="line"/>
-      <point x="0" y="-183" type="line"/>
+      <point x="1200" y="-182" type="line"/>
+      <point x="0" y="-182" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-ExtraLight.ufo/glyphs/lowerR_ightB_lock.glif
+++ b/sources/CascadiaCode-ExtraLight.ufo/glyphs/lowerR_ightB_lock.glif
@@ -6,8 +6,8 @@
     <contour>
       <point x="600" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="1200" y="873" type="line"/>
+      <point x="600" y="873" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-ExtraLight.ufo/glyphs/lowerR_ightB_lock.stypo.glif
+++ b/sources/CascadiaCode-ExtraLight.ufo/glyphs/lowerR_ightB_lock.stypo.glif
@@ -5,8 +5,8 @@
     <contour>
       <point x="600" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="1200" y="710" type="line"/>
+      <point x="600" y="710" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-ExtraLight.ufo/glyphs/lowerS_evenE_ighthsB_lock.glif
+++ b/sources/CascadiaCode-ExtraLight.ufo/glyphs/lowerS_evenE_ighthsB_lock.glif
@@ -6,8 +6,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="1887" type="line"/>
-      <point x="0" y="1887" type="line"/>
+      <point x="1200" y="1888" type="line"/>
+      <point x="0" y="1888" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-ExtraLight.ufo/glyphs/lowerT_hreeE_ighthsB_lock.glif
+++ b/sources/CascadiaCode-ExtraLight.ufo/glyphs/lowerT_hreeE_ighthsB_lock.glif
@@ -6,8 +6,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="534" type="line"/>
-      <point x="0" y="534" type="line"/>
+      <point x="1200" y="535" type="line"/>
+      <point x="0" y="535" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-ExtraLight.ufo/glyphs/upperH_alfB_lock.glif
+++ b/sources/CascadiaCode-ExtraLight.ufo/glyphs/upperH_alfB_lock.glif
@@ -4,8 +4,8 @@
   <unicode hex="2580"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="0" y="873" type="line"/>
+      <point x="1200" y="873" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
     </contour>

--- a/sources/CascadiaCode-ExtraLight.ufo/glyphs/upperH_alfB_lock.stypo.glif
+++ b/sources/CascadiaCode-ExtraLight.ufo/glyphs/upperH_alfB_lock.stypo.glif
@@ -3,8 +3,8 @@
   <advance width="1200"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="0" y="710" type="line"/>
+      <point x="1200" y="710" type="line"/>
       <point x="1200" y="1900" type="line"/>
       <point x="0" y="1900" type="line"/>
     </contour>

--- a/sources/CascadiaCode-ExtraLight.ufo/glyphs/upperL_eftA_ndL_owerR_ightB_lock.glif
+++ b/sources/CascadiaCode-ExtraLight.ufo/glyphs/upperL_eftA_ndL_owerR_ightB_lock.glif
@@ -4,16 +4,16 @@
   <unicode hex="259A"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="873" type="line"/>
+      <point x="600" y="873" type="line"/>
       <point x="600" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
     </contour>
     <contour>
       <point x="600" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="1200" y="873" type="line"/>
+      <point x="600" y="873" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-ExtraLight.ufo/glyphs/upperL_eftA_ndL_owerR_ightB_lock.stypo.glif
+++ b/sources/CascadiaCode-ExtraLight.ufo/glyphs/upperL_eftA_ndL_owerR_ightB_lock.stypo.glif
@@ -3,16 +3,16 @@
   <advance width="1200"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="710" type="line"/>
+      <point x="600" y="710" type="line"/>
       <point x="600" y="1900" type="line"/>
       <point x="0" y="1900" type="line"/>
     </contour>
     <contour>
       <point x="600" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="1200" y="710" type="line"/>
+      <point x="600" y="710" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-ExtraLight.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerL_eftB_lock.glif
+++ b/sources/CascadiaCode-ExtraLight.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerL_eftB_lock.glif
@@ -6,8 +6,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="600" y="-480" type="line"/>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="873" type="line"/>
+      <point x="1200" y="873" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
     </contour>

--- a/sources/CascadiaCode-ExtraLight.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerL_eftB_lock.stypo.glif
+++ b/sources/CascadiaCode-ExtraLight.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerL_eftB_lock.stypo.glif
@@ -5,8 +5,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="600" y="-480" type="line"/>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="710" type="line"/>
+      <point x="1200" y="710" type="line"/>
       <point x="1200" y="1900" type="line"/>
       <point x="0" y="1900" type="line"/>
     </contour>

--- a/sources/CascadiaCode-ExtraLight.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerR_ightB_lock.glif
+++ b/sources/CascadiaCode-ExtraLight.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerR_ightB_lock.glif
@@ -8,8 +8,8 @@
       <point x="1200" y="-480" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="873" type="line"/>
+      <point x="600" y="873" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-ExtraLight.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerR_ightB_lock.stypo.glif
+++ b/sources/CascadiaCode-ExtraLight.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerR_ightB_lock.stypo.glif
@@ -7,8 +7,8 @@
       <point x="1200" y="-480" type="line"/>
       <point x="1200" y="1900" type="line"/>
       <point x="0" y="1900" type="line"/>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="710" type="line"/>
+      <point x="600" y="710" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-ExtraLight.ufo/glyphs/upperL_eftB_lock.glif
+++ b/sources/CascadiaCode-ExtraLight.ufo/glyphs/upperL_eftB_lock.glif
@@ -4,8 +4,8 @@
   <unicode hex="2598"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="873" type="line"/>
+      <point x="600" y="873" type="line"/>
       <point x="600" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
     </contour>

--- a/sources/CascadiaCode-ExtraLight.ufo/glyphs/upperL_eftB_lock.stypo.glif
+++ b/sources/CascadiaCode-ExtraLight.ufo/glyphs/upperL_eftB_lock.stypo.glif
@@ -3,8 +3,8 @@
   <advance width="1200"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="710" type="line"/>
+      <point x="600" y="710" type="line"/>
       <point x="600" y="1900" type="line"/>
       <point x="0" y="1900" type="line"/>
     </contour>

--- a/sources/CascadiaCode-ExtraLight.ufo/glyphs/upperO_neE_ighthB_lock.glif
+++ b/sources/CascadiaCode-ExtraLight.ufo/glyphs/upperO_neE_ighthB_lock.glif
@@ -4,8 +4,8 @@
   <unicode hex="2594"/>
   <outline>
     <contour>
-      <point x="0" y="1887" type="line"/>
-      <point x="1200" y="1887" type="line"/>
+      <point x="0" y="1888" type="line"/>
+      <point x="1200" y="1888" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
     </contour>

--- a/sources/CascadiaCode-ExtraLight.ufo/glyphs/upperR_ightA_ndL_owerL_eftB_lock.glif
+++ b/sources/CascadiaCode-ExtraLight.ufo/glyphs/upperR_ightA_ndL_owerL_eftB_lock.glif
@@ -6,8 +6,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="600" y="-480" type="line"/>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="873" type="line"/>
+      <point x="1200" y="873" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="600" y="2226" type="line"/>
       <point x="600" y="873" type="line"/>

--- a/sources/CascadiaCode-ExtraLight.ufo/glyphs/upperR_ightA_ndL_owerL_eftB_lock.stypo.glif
+++ b/sources/CascadiaCode-ExtraLight.ufo/glyphs/upperR_ightA_ndL_owerL_eftB_lock.stypo.glif
@@ -5,8 +5,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="600" y="-480" type="line"/>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="710" type="line"/>
+      <point x="1200" y="710" type="line"/>
       <point x="1200" y="1900" type="line"/>
       <point x="600" y="1900" type="line"/>
       <point x="600" y="710" type="line"/>

--- a/sources/CascadiaCode-ExtraLight.ufo/glyphs/upperR_ightB_lock.glif
+++ b/sources/CascadiaCode-ExtraLight.ufo/glyphs/upperR_ightB_lock.glif
@@ -4,8 +4,8 @@
   <unicode hex="259D"/>
   <outline>
     <contour>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="873" type="line"/>
+      <point x="1200" y="873" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="600" y="2226" type="line"/>
     </contour>

--- a/sources/CascadiaCode-ExtraLight.ufo/glyphs/upperR_ightB_lock.stypo.glif
+++ b/sources/CascadiaCode-ExtraLight.ufo/glyphs/upperR_ightB_lock.stypo.glif
@@ -3,8 +3,8 @@
   <advance width="1200"/>
   <outline>
     <contour>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="710" type="line"/>
+      <point x="1200" y="710" type="line"/>
       <point x="1200" y="1900" type="line"/>
       <point x="600" y="1900" type="line"/>
     </contour>

--- a/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/lowerO_neE_ighthB_lock.stypo.glif
+++ b/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/lowerO_neE_ighthB_lock.stypo.glif
@@ -5,8 +5,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="-183" type="line"/>
-      <point x="0" y="-183" type="line"/>
+      <point x="1200" y="-182" type="line"/>
+      <point x="0" y="-182" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/lowerR_ightB_lock.glif
+++ b/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/lowerR_ightB_lock.glif
@@ -6,8 +6,8 @@
     <contour>
       <point x="600" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="1200" y="873" type="line"/>
+      <point x="600" y="873" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/lowerR_ightB_lock.stypo.glif
+++ b/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/lowerR_ightB_lock.stypo.glif
@@ -5,8 +5,8 @@
     <contour>
       <point x="600" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="1200" y="710" type="line"/>
+      <point x="600" y="710" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/lowerS_evenE_ighthsB_lock.glif
+++ b/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/lowerS_evenE_ighthsB_lock.glif
@@ -6,8 +6,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="1887" type="line"/>
-      <point x="0" y="1887" type="line"/>
+      <point x="1200" y="1888" type="line"/>
+      <point x="0" y="1888" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/lowerT_hreeE_ighthsB_lock.glif
+++ b/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/lowerT_hreeE_ighthsB_lock.glif
@@ -6,8 +6,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="534" type="line"/>
-      <point x="0" y="534" type="line"/>
+      <point x="1200" y="535" type="line"/>
+      <point x="0" y="535" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/upperH_alfB_lock.glif
+++ b/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/upperH_alfB_lock.glif
@@ -4,8 +4,8 @@
   <unicode hex="2580"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="0" y="873" type="line"/>
+      <point x="1200" y="873" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
     </contour>

--- a/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/upperH_alfB_lock.stypo.glif
+++ b/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/upperH_alfB_lock.stypo.glif
@@ -3,8 +3,8 @@
   <advance width="1200"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="0" y="710" type="line"/>
+      <point x="1200" y="710" type="line"/>
       <point x="1200" y="1900" type="line"/>
       <point x="0" y="1900" type="line"/>
     </contour>

--- a/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/upperL_eftA_ndL_owerR_ightB_lock.glif
+++ b/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/upperL_eftA_ndL_owerR_ightB_lock.glif
@@ -4,16 +4,16 @@
   <unicode hex="259A"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="873" type="line"/>
+      <point x="600" y="873" type="line"/>
       <point x="600" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
     </contour>
     <contour>
       <point x="600" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="1200" y="873" type="line"/>
+      <point x="600" y="873" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/upperL_eftA_ndL_owerR_ightB_lock.stypo.glif
+++ b/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/upperL_eftA_ndL_owerR_ightB_lock.stypo.glif
@@ -3,16 +3,16 @@
   <advance width="1200"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="710" type="line"/>
+      <point x="600" y="710" type="line"/>
       <point x="600" y="1900" type="line"/>
       <point x="0" y="1900" type="line"/>
     </contour>
     <contour>
       <point x="600" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="1200" y="710" type="line"/>
+      <point x="600" y="710" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerL_eftB_lock.glif
+++ b/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerL_eftB_lock.glif
@@ -6,8 +6,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="600" y="-480" type="line"/>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="873" type="line"/>
+      <point x="1200" y="873" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
     </contour>

--- a/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerL_eftB_lock.stypo.glif
+++ b/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerL_eftB_lock.stypo.glif
@@ -5,8 +5,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="600" y="-480" type="line"/>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="710" type="line"/>
+      <point x="1200" y="710" type="line"/>
       <point x="1200" y="1900" type="line"/>
       <point x="0" y="1900" type="line"/>
     </contour>

--- a/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerR_ightB_lock.glif
+++ b/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerR_ightB_lock.glif
@@ -8,8 +8,8 @@
       <point x="1200" y="-480" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="873" type="line"/>
+      <point x="600" y="873" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerR_ightB_lock.stypo.glif
+++ b/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerR_ightB_lock.stypo.glif
@@ -7,8 +7,8 @@
       <point x="1200" y="-480" type="line"/>
       <point x="1200" y="1900" type="line"/>
       <point x="0" y="1900" type="line"/>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="710" type="line"/>
+      <point x="600" y="710" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/upperL_eftB_lock.glif
+++ b/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/upperL_eftB_lock.glif
@@ -4,8 +4,8 @@
   <unicode hex="2598"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="873" type="line"/>
+      <point x="600" y="873" type="line"/>
       <point x="600" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
     </contour>

--- a/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/upperL_eftB_lock.stypo.glif
+++ b/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/upperL_eftB_lock.stypo.glif
@@ -3,8 +3,8 @@
   <advance width="1200"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="710" type="line"/>
+      <point x="600" y="710" type="line"/>
       <point x="600" y="1900" type="line"/>
       <point x="0" y="1900" type="line"/>
     </contour>

--- a/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/upperO_neE_ighthB_lock.glif
+++ b/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/upperO_neE_ighthB_lock.glif
@@ -4,8 +4,8 @@
   <unicode hex="2594"/>
   <outline>
     <contour>
-      <point x="0" y="1887" type="line"/>
-      <point x="1200" y="1887" type="line"/>
+      <point x="0" y="1888" type="line"/>
+      <point x="1200" y="1888" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
     </contour>

--- a/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/upperR_ightA_ndL_owerL_eftB_lock.glif
+++ b/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/upperR_ightA_ndL_owerL_eftB_lock.glif
@@ -6,8 +6,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="600" y="-480" type="line"/>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="873" type="line"/>
+      <point x="1200" y="873" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="600" y="2226" type="line"/>
       <point x="600" y="873" type="line"/>

--- a/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/upperR_ightA_ndL_owerL_eftB_lock.stypo.glif
+++ b/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/upperR_ightA_ndL_owerL_eftB_lock.stypo.glif
@@ -5,8 +5,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="600" y="-480" type="line"/>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="710" type="line"/>
+      <point x="1200" y="710" type="line"/>
       <point x="1200" y="1900" type="line"/>
       <point x="600" y="1900" type="line"/>
       <point x="600" y="710" type="line"/>

--- a/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/upperR_ightB_lock.glif
+++ b/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/upperR_ightB_lock.glif
@@ -4,8 +4,8 @@
   <unicode hex="259D"/>
   <outline>
     <contour>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="873" type="line"/>
+      <point x="1200" y="873" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="600" y="2226" type="line"/>
     </contour>

--- a/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/upperR_ightB_lock.stypo.glif
+++ b/sources/CascadiaCode-ExtraLightItalic.ufo/glyphs/upperR_ightB_lock.stypo.glif
@@ -3,8 +3,8 @@
   <advance width="1200"/>
   <outline>
     <contour>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="710" type="line"/>
+      <point x="1200" y="710" type="line"/>
       <point x="1200" y="1900" type="line"/>
       <point x="600" y="1900" type="line"/>
     </contour>

--- a/sources/CascadiaCode-Italic.ufo/glyphs/lowerO_neE_ighthB_lock.stypo.glif
+++ b/sources/CascadiaCode-Italic.ufo/glyphs/lowerO_neE_ighthB_lock.stypo.glif
@@ -5,8 +5,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="-183" type="line"/>
-      <point x="0" y="-183" type="line"/>
+      <point x="1200" y="-182" type="line"/>
+      <point x="0" y="-182" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-Italic.ufo/glyphs/lowerR_ightB_lock.glif
+++ b/sources/CascadiaCode-Italic.ufo/glyphs/lowerR_ightB_lock.glif
@@ -6,8 +6,8 @@
     <contour>
       <point x="600" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="1200" y="873" type="line"/>
+      <point x="600" y="873" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-Italic.ufo/glyphs/lowerR_ightB_lock.stypo.glif
+++ b/sources/CascadiaCode-Italic.ufo/glyphs/lowerR_ightB_lock.stypo.glif
@@ -5,8 +5,8 @@
     <contour>
       <point x="600" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="1200" y="710" type="line"/>
+      <point x="600" y="710" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-Italic.ufo/glyphs/lowerS_evenE_ighthsB_lock.glif
+++ b/sources/CascadiaCode-Italic.ufo/glyphs/lowerS_evenE_ighthsB_lock.glif
@@ -6,8 +6,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="1887" type="line"/>
-      <point x="0" y="1887" type="line"/>
+      <point x="1200" y="1888" type="line"/>
+      <point x="0" y="1888" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-Italic.ufo/glyphs/lowerT_hreeE_ighthsB_lock.glif
+++ b/sources/CascadiaCode-Italic.ufo/glyphs/lowerT_hreeE_ighthsB_lock.glif
@@ -6,8 +6,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="534" type="line"/>
-      <point x="0" y="534" type="line"/>
+      <point x="1200" y="535" type="line"/>
+      <point x="0" y="535" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-Italic.ufo/glyphs/upperH_alfB_lock.glif
+++ b/sources/CascadiaCode-Italic.ufo/glyphs/upperH_alfB_lock.glif
@@ -4,8 +4,8 @@
   <unicode hex="2580"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="0" y="873" type="line"/>
+      <point x="1200" y="873" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
     </contour>

--- a/sources/CascadiaCode-Italic.ufo/glyphs/upperH_alfB_lock.stypo.glif
+++ b/sources/CascadiaCode-Italic.ufo/glyphs/upperH_alfB_lock.stypo.glif
@@ -3,8 +3,8 @@
   <advance width="1200"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="0" y="710" type="line"/>
+      <point x="1200" y="710" type="line"/>
       <point x="1200" y="1900" type="line"/>
       <point x="0" y="1900" type="line"/>
     </contour>

--- a/sources/CascadiaCode-Italic.ufo/glyphs/upperL_eftA_ndL_owerR_ightB_lock.glif
+++ b/sources/CascadiaCode-Italic.ufo/glyphs/upperL_eftA_ndL_owerR_ightB_lock.glif
@@ -4,16 +4,16 @@
   <unicode hex="259A"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="873" type="line"/>
+      <point x="600" y="873" type="line"/>
       <point x="600" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
     </contour>
     <contour>
       <point x="600" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="1200" y="873" type="line"/>
+      <point x="600" y="873" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-Italic.ufo/glyphs/upperL_eftA_ndL_owerR_ightB_lock.stypo.glif
+++ b/sources/CascadiaCode-Italic.ufo/glyphs/upperL_eftA_ndL_owerR_ightB_lock.stypo.glif
@@ -3,16 +3,16 @@
   <advance width="1200"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="710" type="line"/>
+      <point x="600" y="710" type="line"/>
       <point x="600" y="1900" type="line"/>
       <point x="0" y="1900" type="line"/>
     </contour>
     <contour>
       <point x="600" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="1200" y="710" type="line"/>
+      <point x="600" y="710" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-Italic.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerL_eftB_lock.glif
+++ b/sources/CascadiaCode-Italic.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerL_eftB_lock.glif
@@ -6,8 +6,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="600" y="-480" type="line"/>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="873" type="line"/>
+      <point x="1200" y="873" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
     </contour>

--- a/sources/CascadiaCode-Italic.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerL_eftB_lock.stypo.glif
+++ b/sources/CascadiaCode-Italic.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerL_eftB_lock.stypo.glif
@@ -5,8 +5,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="600" y="-480" type="line"/>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="710" type="line"/>
+      <point x="1200" y="710" type="line"/>
       <point x="1200" y="1900" type="line"/>
       <point x="0" y="1900" type="line"/>
     </contour>

--- a/sources/CascadiaCode-Italic.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerR_ightB_lock.glif
+++ b/sources/CascadiaCode-Italic.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerR_ightB_lock.glif
@@ -8,8 +8,8 @@
       <point x="1200" y="-480" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="873" type="line"/>
+      <point x="600" y="873" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-Italic.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerR_ightB_lock.stypo.glif
+++ b/sources/CascadiaCode-Italic.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerR_ightB_lock.stypo.glif
@@ -7,8 +7,8 @@
       <point x="1200" y="-480" type="line"/>
       <point x="1200" y="1900" type="line"/>
       <point x="0" y="1900" type="line"/>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="710" type="line"/>
+      <point x="600" y="710" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-Italic.ufo/glyphs/upperL_eftB_lock.glif
+++ b/sources/CascadiaCode-Italic.ufo/glyphs/upperL_eftB_lock.glif
@@ -4,8 +4,8 @@
   <unicode hex="2598"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="873" type="line"/>
+      <point x="600" y="873" type="line"/>
       <point x="600" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
     </contour>

--- a/sources/CascadiaCode-Italic.ufo/glyphs/upperL_eftB_lock.stypo.glif
+++ b/sources/CascadiaCode-Italic.ufo/glyphs/upperL_eftB_lock.stypo.glif
@@ -3,8 +3,8 @@
   <advance width="1200"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="710" type="line"/>
+      <point x="600" y="710" type="line"/>
       <point x="600" y="1900" type="line"/>
       <point x="0" y="1900" type="line"/>
     </contour>

--- a/sources/CascadiaCode-Italic.ufo/glyphs/upperO_neE_ighthB_lock.glif
+++ b/sources/CascadiaCode-Italic.ufo/glyphs/upperO_neE_ighthB_lock.glif
@@ -4,8 +4,8 @@
   <unicode hex="2594"/>
   <outline>
     <contour>
-      <point x="0" y="1887" type="line"/>
-      <point x="1200" y="1887" type="line"/>
+      <point x="0" y="1888" type="line"/>
+      <point x="1200" y="1888" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
     </contour>

--- a/sources/CascadiaCode-Italic.ufo/glyphs/upperR_ightA_ndL_owerL_eftB_lock.glif
+++ b/sources/CascadiaCode-Italic.ufo/glyphs/upperR_ightA_ndL_owerL_eftB_lock.glif
@@ -6,8 +6,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="600" y="-480" type="line"/>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="873" type="line"/>
+      <point x="1200" y="873" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="600" y="2226" type="line"/>
       <point x="600" y="873" type="line"/>

--- a/sources/CascadiaCode-Italic.ufo/glyphs/upperR_ightA_ndL_owerL_eftB_lock.stypo.glif
+++ b/sources/CascadiaCode-Italic.ufo/glyphs/upperR_ightA_ndL_owerL_eftB_lock.stypo.glif
@@ -5,8 +5,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="600" y="-480" type="line"/>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="710" type="line"/>
+      <point x="1200" y="710" type="line"/>
       <point x="1200" y="1900" type="line"/>
       <point x="600" y="1900" type="line"/>
       <point x="600" y="710" type="line"/>

--- a/sources/CascadiaCode-Italic.ufo/glyphs/upperR_ightB_lock.glif
+++ b/sources/CascadiaCode-Italic.ufo/glyphs/upperR_ightB_lock.glif
@@ -4,8 +4,8 @@
   <unicode hex="259D"/>
   <outline>
     <contour>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="873" type="line"/>
+      <point x="1200" y="873" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="600" y="2226" type="line"/>
     </contour>

--- a/sources/CascadiaCode-Italic.ufo/glyphs/upperR_ightB_lock.stypo.glif
+++ b/sources/CascadiaCode-Italic.ufo/glyphs/upperR_ightB_lock.stypo.glif
@@ -3,8 +3,8 @@
   <advance width="1200"/>
   <outline>
     <contour>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="710" type="line"/>
+      <point x="1200" y="710" type="line"/>
       <point x="1200" y="1900" type="line"/>
       <point x="600" y="1900" type="line"/>
     </contour>

--- a/sources/CascadiaCode-Regular.ufo/glyphs/lowerO_neE_ighthB_lock.stypo.glif
+++ b/sources/CascadiaCode-Regular.ufo/glyphs/lowerO_neE_ighthB_lock.stypo.glif
@@ -5,8 +5,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="-183" type="line"/>
-      <point x="0" y="-183" type="line"/>
+      <point x="1200" y="-182" type="line"/>
+      <point x="0" y="-182" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-Regular.ufo/glyphs/lowerR_ightB_lock.glif
+++ b/sources/CascadiaCode-Regular.ufo/glyphs/lowerR_ightB_lock.glif
@@ -6,8 +6,8 @@
     <contour>
       <point x="600" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="1200" y="873" type="line"/>
+      <point x="600" y="873" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-Regular.ufo/glyphs/lowerR_ightB_lock.stypo.glif
+++ b/sources/CascadiaCode-Regular.ufo/glyphs/lowerR_ightB_lock.stypo.glif
@@ -5,8 +5,8 @@
     <contour>
       <point x="600" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="1200" y="710" type="line"/>
+      <point x="600" y="710" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-Regular.ufo/glyphs/lowerS_evenE_ighthsB_lock.glif
+++ b/sources/CascadiaCode-Regular.ufo/glyphs/lowerS_evenE_ighthsB_lock.glif
@@ -6,8 +6,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="1887" type="line"/>
-      <point x="0" y="1887" type="line"/>
+      <point x="1200" y="1888" type="line"/>
+      <point x="0" y="1888" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-Regular.ufo/glyphs/lowerT_hreeE_ighthsB_lock.glif
+++ b/sources/CascadiaCode-Regular.ufo/glyphs/lowerT_hreeE_ighthsB_lock.glif
@@ -6,8 +6,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="534" type="line"/>
-      <point x="0" y="534" type="line"/>
+      <point x="1200" y="535" type="line"/>
+      <point x="0" y="535" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-Regular.ufo/glyphs/upperH_alfB_lock.glif
+++ b/sources/CascadiaCode-Regular.ufo/glyphs/upperH_alfB_lock.glif
@@ -4,8 +4,8 @@
   <unicode hex="2580"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="0" y="873" type="line"/>
+      <point x="1200" y="873" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
     </contour>

--- a/sources/CascadiaCode-Regular.ufo/glyphs/upperH_alfB_lock.stypo.glif
+++ b/sources/CascadiaCode-Regular.ufo/glyphs/upperH_alfB_lock.stypo.glif
@@ -3,8 +3,8 @@
   <advance width="1200"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="0" y="710" type="line"/>
+      <point x="1200" y="710" type="line"/>
       <point x="1200" y="1900" type="line"/>
       <point x="0" y="1900" type="line"/>
     </contour>

--- a/sources/CascadiaCode-Regular.ufo/glyphs/upperL_eftA_ndL_owerR_ightB_lock.glif
+++ b/sources/CascadiaCode-Regular.ufo/glyphs/upperL_eftA_ndL_owerR_ightB_lock.glif
@@ -4,16 +4,16 @@
   <unicode hex="259A"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="873" type="line"/>
+      <point x="600" y="873" type="line"/>
       <point x="600" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
     </contour>
     <contour>
       <point x="600" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="1200" y="873" type="line"/>
+      <point x="600" y="873" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-Regular.ufo/glyphs/upperL_eftA_ndL_owerR_ightB_lock.stypo.glif
+++ b/sources/CascadiaCode-Regular.ufo/glyphs/upperL_eftA_ndL_owerR_ightB_lock.stypo.glif
@@ -3,16 +3,16 @@
   <advance width="1200"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="710" type="line"/>
+      <point x="600" y="710" type="line"/>
       <point x="600" y="1900" type="line"/>
       <point x="0" y="1900" type="line"/>
     </contour>
     <contour>
       <point x="600" y="-480" type="line"/>
       <point x="1200" y="-480" type="line"/>
-      <point x="1200" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="1200" y="710" type="line"/>
+      <point x="600" y="710" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-Regular.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerL_eftB_lock.glif
+++ b/sources/CascadiaCode-Regular.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerL_eftB_lock.glif
@@ -6,8 +6,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="600" y="-480" type="line"/>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="873" type="line"/>
+      <point x="1200" y="873" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
     </contour>

--- a/sources/CascadiaCode-Regular.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerL_eftB_lock.stypo.glif
+++ b/sources/CascadiaCode-Regular.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerL_eftB_lock.stypo.glif
@@ -5,8 +5,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="600" y="-480" type="line"/>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="710" type="line"/>
+      <point x="1200" y="710" type="line"/>
       <point x="1200" y="1900" type="line"/>
       <point x="0" y="1900" type="line"/>
     </contour>

--- a/sources/CascadiaCode-Regular.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerR_ightB_lock.glif
+++ b/sources/CascadiaCode-Regular.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerR_ightB_lock.glif
@@ -8,8 +8,8 @@
       <point x="1200" y="-480" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="873" type="line"/>
+      <point x="600" y="873" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-Regular.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerR_ightB_lock.stypo.glif
+++ b/sources/CascadiaCode-Regular.ufo/glyphs/upperL_eftA_ndU_pperR_ightA_ndL_owerR_ightB_lock.stypo.glif
@@ -7,8 +7,8 @@
       <point x="1200" y="-480" type="line"/>
       <point x="1200" y="1900" type="line"/>
       <point x="0" y="1900" type="line"/>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="710" type="line"/>
+      <point x="600" y="710" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/CascadiaCode-Regular.ufo/glyphs/upperL_eftB_lock.glif
+++ b/sources/CascadiaCode-Regular.ufo/glyphs/upperL_eftB_lock.glif
@@ -4,8 +4,8 @@
   <unicode hex="2598"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="873" type="line"/>
+      <point x="600" y="873" type="line"/>
       <point x="600" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
     </contour>

--- a/sources/CascadiaCode-Regular.ufo/glyphs/upperL_eftB_lock.stypo.glif
+++ b/sources/CascadiaCode-Regular.ufo/glyphs/upperL_eftB_lock.stypo.glif
@@ -3,8 +3,8 @@
   <advance width="1200"/>
   <outline>
     <contour>
-      <point x="0" y="707" type="line"/>
-      <point x="600" y="707" type="line"/>
+      <point x="0" y="710" type="line"/>
+      <point x="600" y="710" type="line"/>
       <point x="600" y="1900" type="line"/>
       <point x="0" y="1900" type="line"/>
     </contour>

--- a/sources/CascadiaCode-Regular.ufo/glyphs/upperO_neE_ighthB_lock.glif
+++ b/sources/CascadiaCode-Regular.ufo/glyphs/upperO_neE_ighthB_lock.glif
@@ -4,8 +4,8 @@
   <unicode hex="2594"/>
   <outline>
     <contour>
-      <point x="0" y="1887" type="line"/>
-      <point x="1200" y="1887" type="line"/>
+      <point x="0" y="1888" type="line"/>
+      <point x="1200" y="1888" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="0" y="2226" type="line"/>
     </contour>

--- a/sources/CascadiaCode-Regular.ufo/glyphs/upperR_ightA_ndL_owerL_eftB_lock.glif
+++ b/sources/CascadiaCode-Regular.ufo/glyphs/upperR_ightA_ndL_owerL_eftB_lock.glif
@@ -6,8 +6,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="600" y="-480" type="line"/>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="873" type="line"/>
+      <point x="1200" y="873" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="600" y="2226" type="line"/>
       <point x="600" y="873" type="line"/>

--- a/sources/CascadiaCode-Regular.ufo/glyphs/upperR_ightA_ndL_owerL_eftB_lock.stypo.glif
+++ b/sources/CascadiaCode-Regular.ufo/glyphs/upperR_ightA_ndL_owerL_eftB_lock.stypo.glif
@@ -5,8 +5,8 @@
     <contour>
       <point x="0" y="-480" type="line"/>
       <point x="600" y="-480" type="line"/>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="710" type="line"/>
+      <point x="1200" y="710" type="line"/>
       <point x="1200" y="1900" type="line"/>
       <point x="600" y="1900" type="line"/>
       <point x="600" y="710" type="line"/>

--- a/sources/CascadiaCode-Regular.ufo/glyphs/upperR_ightB_lock.glif
+++ b/sources/CascadiaCode-Regular.ufo/glyphs/upperR_ightB_lock.glif
@@ -4,8 +4,8 @@
   <unicode hex="259D"/>
   <outline>
     <contour>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="873" type="line"/>
+      <point x="1200" y="873" type="line"/>
       <point x="1200" y="2226" type="line"/>
       <point x="600" y="2226" type="line"/>
     </contour>

--- a/sources/CascadiaCode-Regular.ufo/glyphs/upperR_ightB_lock.stypo.glif
+++ b/sources/CascadiaCode-Regular.ufo/glyphs/upperR_ightB_lock.stypo.glif
@@ -3,8 +3,8 @@
   <advance width="1200"/>
   <outline>
     <contour>
-      <point x="600" y="707" type="line"/>
-      <point x="1200" y="707" type="line"/>
+      <point x="600" y="710" type="line"/>
+      <point x="1200" y="710" type="line"/>
       <point x="1200" y="1900" type="line"/>
       <point x="600" y="1900" type="line"/>
     </contour>


### PR DESCRIPTION
This update adjusts the points coordinates of some previously existing blocks/mosaics characters to fit them in the same grid as used by octants and eights.
This is required because the new octants and eights from Symbols for Legacy Computing do not duplicate existing patterns and expect those existing one to join perfectly with them to provide the whole set of all possible pseudopixels mosaics.

## Description of the Pull Request

This update verifies and adjusts the existing characters that are now required to join seamlessly with the extended pseudo-pixels mosaics introduced with the symbols for legacy computing.
Some of the existing characters were not proper mosaics, most notably `▞`, where the two black rectangles overlap because they don't use the same y coordinates.
This shouldn't happen as all the mosaics are supposed to fit precisely on a unified grid.
Only a few characters required adjustments, but this PR also documents all the glyphs that have been checked to ensure alignments of all the mosaic characters.

**BLOCKS:**
`U+00A0` nbspace : already correct
`U+2588` fullBlock & fullBlock.stypo : already correct (used as reference bounding rectangle for all pseudopixels mosaics)

**HALF-BLOCKS:**
`U+2580` upperHalfBlock & upperHalfBlock.stypo : y=50% fixed from 707 to 873 (gdi) and 710 (stypo)
`U+2584` lowerHalfBlock & lowerHalfBlock.stypo : already correct (confirming upperHalfBlock y=50% was wrong)
`U+258C` leftBlock & leftBlock.stypo : already correct
`U+2590` rightBlock & rightBlock.stypo : already correct

**QUADRANTS:**
`U+2596` lowerLeftBlock & lowerLeftBlock.stypo : already correct (confirming all other corrections above and below)
`U+2597` lowerRightBlock & lowerRightBlock.stypo : y=50% fixed from 707 to 873 (gdi) and 710 (stypo)
`U+2598` upperLeftBlock & upperLeftBlock.stypo : y=50% fixed from 707 to 873 (gdi) and 710 (stypo)
`U+2599` upperLeftAndLowerLeftAndLowerRightBlock & upperLeftAndLowerLeftAndLowerRightBlock.stypo : already correct
`U+259A` upperLeftAndLowerRightBlock & upperLeftAndLowerRightBlock.stypo : y=50% fixed from 707 to 873 (gdi) and 710 (stypo)
`U+259B` upperLeftAndUpperRightAndLowerLeftBlock & upperLeftAndUpperRightAndLowerLeftBlock.stypo : y=50% fixed from 707 to 873 (gdi) and 710 (stypo)
`U+259C` upperLeftAndUpperRightAndLowerRightBlock & upperLeftAndUpperRightAndLowerRightBlock.stypo : y=50% fixed from 707 to 873 (gdi) and 710 (stypo)
`U+259D` upperRightBlock & upperRightBlock.stypo : y=50% fixed from 707 to 873 (gdi) and 710 (stypo)
`U+259E` upperRightAndLowerLeftBlock & upperRightAndLowerLeftBlock.stypo : Some y=50% fixed from 707 to 873 (gdi) and 710 (stypo), some were already correct
`U+259F` upperRightAndLowerLeftAndLowerRightBlock & upperRightAndLowerLeftAndLowerRightBlock.stypo : already correct

**OCTANTS:**
`U+2582` lowerOneQuarterBlock & lowerOneQuarterBlock.stypo : already correct
`U+2586` lowerThreeQuartersBlock & lowerThreeQuartersBlock.stypo : already correct

**EIGHTS:**
`U+2581` lowerOneEighthBlock & lowerOneEighthBlock.stypo : gdi was correct, y fixed from -183 to -182 (rounding unification for all Eights) for stypo
`U+2583` lowerThreeEighthsBlock & lowerThreeEighthsBlock.stypo : y fixed from 534 to 535 (rounding unification for all Eights) for GDI, stypo was correct
`U+2585` lowerFiveEighthsBlock & lowerFiveEighthsBlock.stypo : already correct
`U+2587` lowerSevenEighthsBlock & lowerSevenEighthsBlock.stypo : y fixed from 1887 to 1888 (rounding unification for all Eights) for GDI, stypo was correct
`U+2594` upperOneEighthBlock & upperOneEighthBlock.stypo : y fixed from 1887 to 1888 (rounding unification for all Eights) for GDI, stypo was correct
`U+1FB83` upperThreeEighthsBlock & upperThreeEighthsBlock.stypo : from my PR #723
`U+1FB86` upperSevenEighthsBlock & upperSevenEighthsBlock.stypo : from my PR #723

`U+2589` leftSevenEighthsBlock & leftSevenEighthsBlock.stypo : already correct
`U+258A` leftThreeQuartersBlock & leftThreeQuartersBlock.stypo : already correct
`U+258B` leftFiveEighthsBlock & leftFiveEighthsBlock.stypo : already correct
`U+258D` leftThreeEighthsBlock & leftThreeEighthsBlock.stypo : already correct
`U+258E` leftOneQuarterBlock & leftOneQuarterBlock.stypo : already correct
`U+258F` leftOneEighthBlock & leftOneEighthBlock.stypo : already correct

`U+2595` rightOneEighthBlock & rightOneEighthBlock.stypo : already correct
`U+1FB87` rightOneQuarterBlock & rightOneQuarterBlock.stypo : from my PR #723
`U+1FB88` rightThreeEighthsBlock & rightThreeEighthsBlock.stypo : from my PR #723
`U+1FB89` rightFiveEighthsBlock & rightFiveEighthsBlock.stypo : from my PR #723
`U+1FB8A` rightThreeQuartersBlock & rightThreeQuartersBlock.stypo : from my PR #723
`U+1FB8B` rightSevenEighthsBlock & rightSevenEighthsBlock.stypo : from my PR #723

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
This fixes the inconsistent alignments problem explained in issue #644, and ensures unified grid coordinates with PR #708 and #723.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #644
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Requires FONTLOG.txt to be updated (only small fixes, nothing to add to the log)
* [ ] Requires images to be updated (no new character and changes small enough that they probably wouldn't even show at that size)
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #644

## Validation Steps Performed
Based on purely mathematical grid coordinates already used for octants, checked visually in VTT, Terminal Preview 1.20.10822.0 and Canary 1.21.240424002-llm, and Visual Studio editor.

Note there is another related issue that impacts some of those characters, but this PR at least provides the correct glyphs and improves the situation. I believe the remaining alignment issue to be a problem in Terminal itself as it works perfectly in Visual Studio editor, and the original Cascadia Mono 2111.001 exhibits the same issue. More details about this in #644.
Having the proper coordinates at least ensures they won't induce in error someone trying to fix the Terminal rendering and expecting the alignments to work with a font using inconsistent glyphs coordinates. A believe this PR to be a step in the right direction.