### PR TITLE
Complete the branch rename from master to main (again)

### DIFF
--- a/sources/CascadiaCode-BoldItalic.ufo/fontinfo.plist
+++ b/sources/CascadiaCode-BoldItalic.ufo/fontinfo.plist
@@ -250,7 +250,7 @@
     <key>openTypeNameLicense</key>
     <string>Microsoft supplied font. You may use this font to create, display, and print content as permitted by the license terms or terms of use, of the Microsoft product, service, or content in which this font was included. You may only (i) embed this font in content as permitted by the embedding restrictions included in this font; and (ii) temporarily download this font to a printer or other output device to help print content. Any other use is prohibited.
  
-The following license, based on the SIL Open Font license (https://scripts.sil.org/OFL), applies to this font. Additional license terms may be found on the GitHub repository for this font (https://github.com/microsoft/cascadia-code/blob/master/LICENSE).
+The following license, based on the SIL Open Font license (https://scripts.sil.org/OFL), applies to this font. Additional license terms may be found on the GitHub repository for this font (https://github.com/microsoft/cascadia-code/blob/main/LICENSE).
  
 Permission is hereby granted, free of charge, to any person obtaining a copy of the Font Software, to use, study, copy, merge, embed, modify, redistribute, and sell modified and unmodified copies of the Font Software, subject to the following conditions:
  

--- a/sources/CascadiaCode-ExtraLightItalic.ufo/fontinfo.plist
+++ b/sources/CascadiaCode-ExtraLightItalic.ufo/fontinfo.plist
@@ -250,7 +250,7 @@
     <key>openTypeNameLicense</key>
     <string>Microsoft supplied font. You may use this font to create, display, and print content as permitted by the license terms or terms of use, of the Microsoft product, service, or content in which this font was included. You may only (i) embed this font in content as permitted by the embedding restrictions included in this font; and (ii) temporarily download this font to a printer or other output device to help print content. Any other use is prohibited.
  
-The following license, based on the SIL Open Font license (https://scripts.sil.org/OFL), applies to this font. Additional license terms may be found on the GitHub repository for this font (https://github.com/microsoft/cascadia-code/blob/master/LICENSE).
+The following license, based on the SIL Open Font license (https://scripts.sil.org/OFL), applies to this font. Additional license terms may be found on the GitHub repository for this font (https://github.com/microsoft/cascadia-code/blob/main/LICENSE).
  
 Permission is hereby granted, free of charge, to any person obtaining a copy of the Font Software, to use, study, copy, merge, embed, modify, redistribute, and sell modified and unmodified copies of the Font Software, subject to the following conditions:
  

--- a/sources/CascadiaCode-Italic.ufo/fontinfo.plist
+++ b/sources/CascadiaCode-Italic.ufo/fontinfo.plist
@@ -252,7 +252,7 @@
     <key>openTypeNameLicense</key>
     <string>Microsoft supplied font. You may use this font to create, display, and print content as permitted by the license terms or terms of use, of the Microsoft product, service, or content in which this font was included. You may only (i) embed this font in content as permitted by the embedding restrictions included in this font; and (ii) temporarily download this font to a printer or other output device to help print content. Any other use is prohibited.
  
-The following license, based on the SIL Open Font license (https://scripts.sil.org/OFL), applies to this font. Additional license terms may be found on the GitHub repository for this font (https://github.com/microsoft/cascadia-code/blob/master/LICENSE).
+The following license, based on the SIL Open Font license (https://scripts.sil.org/OFL), applies to this font. Additional license terms may be found on the GitHub repository for this font (https://github.com/microsoft/cascadia-code/blob/main/LICENSE).
  
 Permission is hereby granted, free of charge, to any person obtaining a copy of the Font Software, to use, study, copy, merge, embed, modify, redistribute, and sell modified and unmodified copies of the Font Software, subject to the following conditions:
  


### PR DESCRIPTION
## Summary of the Pull Request

Non-italic license strings were updated in Oct. 2020, but italic versions were not.
This commit updates the license string of the remaining italic versions, completing the branch rename from master to main (for good this time).

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx (Haven't post a corresponding issue, can do it you deem it necessary)
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Requires FONTLOG.txt to be updated (No need to)
* [ ] Requires images to be updated (No glyphs modification)
* [ ] I've discussed this with core contributors already. (Nah, you can probably decide based on this PR alone)

## Detailed Description of the Pull Request / Additional comments

I only noticed this when cleaning up custom builds and installing the 2404.23 release, and now I can't unsee it.
Since I still had a fork, I figured I could submit a PR just as fast as submitting an issue. So here it is.

During the October 2020 branch rename from master to main, the license strings were updated in non-italic fonts, but not in italic ones:

Regular, Bold, Light, …
![image](https://github.com/microsoft/cascadia-code/assets/25664275/4e18952d-659e-42ef-909e-0b1b2fdeac84)

Italic, Bold Italic, Light Italic, …
![image](https://github.com/microsoft/cascadia-code/assets/25664275/3cb77393-a4a2-4b1e-b788-4225b283e7c8)

This PR updates the license string in the italic fonts to match the non-italic ones.